### PR TITLE
Support fetching staging slot URL in end-to-end test project

### DIFF
--- a/NuGet.Services.EndToEnd.sln
+++ b/NuGet.Services.EndToEnd.sln
@@ -7,6 +7,21 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D505F569-4DF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.EndToEnd", "src\NuGet.Services.EndToEnd\NuGet.Services.EndToEnd.csproj", "{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{A6B37EC3-8EC7-443D-A928-C328A18886F3}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\Configure-FunctionalTests.ps1 = scripts\Configure-FunctionalTests.ps1
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5BC6A97C-227D-4213-9A6B-58A1FED9ADE6}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		build.ps1 = build.ps1
+		buildandtest.ps1 = buildandtest.ps1
+		NuGet.config = NuGet.config
+		README.md = README.md
+		test.ps1 = test.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/scripts/Configure-Environment.ps1
+++ b/scripts/Configure-Environment.ps1
@@ -14,7 +14,7 @@ Function Get-BaseUrl
 {
     param (
         [string]$ApplicationId,
-        [string]$AzureCertificateThumbprint,
+        [string]$CertificateThumbprint,
         [string]$SubscriptionId,
         [string]$TenantId,
         [string]$BaseUrl,
@@ -32,7 +32,7 @@ Function Get-BaseUrl
 
             $login = Add-AzureRmAccount `
                 -ApplicationId $ApplicationId `
-                -CertificateThumbprint $AzureCertificateThumbprint `
+                -CertificateThumbprint $CertificateThumbprint `
                 -ServicePrincipal `
                 -SubscriptionId $SubscriptionId `
                 -TenantId $TenantId
@@ -59,7 +59,7 @@ Function Get-BaseUrl
 
 $GalleryBaseUrl = Get-BaseUrl `
     -ApplicationId $ApplicationId `
-    -AzureCertificateThumbprint $AzureCertificateThumbprint `
+    -CertificateThumbprint $CertificateThumbprint `
     -SubscriptionId $SubscriptionId `
     -TenantId $TenantId `
     -BaseUrl $GalleryBaseUrl `

--- a/scripts/Configure-Environment.ps1
+++ b/scripts/Configure-Environment.ps1
@@ -7,7 +7,7 @@ param (
     [string]$SubscriptionId,
     [string]$ApplicationId,
     [string]$TenantId,
-    [string]$AzureCertificateThumbprint
+    [string]$CertificateThumbprint
 )
 
 Function Get-BaseUrl

--- a/scripts/Configure-Environment.ps1
+++ b/scripts/Configure-Environment.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding(DefaultParameterSetName='RegularBuild')]
+param (
+    [string]$GalleryBaseUrl,
+    [ValidateSet("Production", "Staging", "", IgnoreCase=$true)]
+    [string]$Slot,
+    [string]$CloudServiceName,
+    [string]$SubscriptionId,
+    [string]$ApplicationId,
+    [string]$TenantId,
+    [string]$AzureCertificateThumbprint
+)
+
+if ($Slot -eq "Staging")
+{
+    # Use Azure PowerShell cmdlets to find the URL of the staging slot.
+    Try
+    {
+        Write-Host "Logging into Azure as service principal."
+
+        $login = Add-AzureRmAccount `
+            -ApplicationId $ApplicationId `
+            -CertificateThumbprint $AzureCertificateThumbprint `
+            -ServicePrincipal `
+            -SubscriptionId $SubscriptionId `
+            -TenantId $TenantId
+
+        Write-Host "Finding cloud service resource '$CloudServiceName'."
+        $resourceGroupName = (Find-AzureRmResource -ResourceNameEquals $CloudServiceName).ResourceGroupName
+
+        Write-Host "Get cloud service resource details for slot '$Slot'."
+        $slotResource = Get-AzureRmResource `
+            -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
+        
+        $GalleryBaseUrl = ($slotResource.Properties.uri).Replace("http", "https")
+    }
+    Catch [System.Exception]
+    {
+        Write-Host "Failed to retrieve URL for testing!"
+        Write-Host $_.Exception.Message
+        Exit 1
+    }
+}
+
+Write-Host "Using the following GalleryBaseUrl: $GalleryBaseUrl" 
+$env:GalleryBaseUrl = $GalleryBaseUrl
+Write-Host "##vso[task.setvariable variable=GalleryBaseUrl;]$GalleryBaseUrl"

--- a/scripts/Configure-Environment.ps1
+++ b/scripts/Configure-Environment.ps1
@@ -2,44 +2,69 @@
 param (
     [string]$GalleryBaseUrl,
     [ValidateSet("Production", "Staging", "", IgnoreCase=$true)]
-    [string]$Slot,
-    [string]$CloudServiceName,
+    [string]$GallerySlot,
+    [string]$GalleryCloudServiceName,
     [string]$SubscriptionId,
     [string]$ApplicationId,
     [string]$TenantId,
     [string]$AzureCertificateThumbprint
 )
 
-if ($Slot -eq "Staging")
+Function Get-BaseUrl
 {
-    # Use Azure PowerShell cmdlets to find the URL of the staging slot.
-    Try
+    param (
+        [string]$ApplicationId,
+        [string]$AzureCertificateThumbprint,
+        [string]$SubscriptionId,
+        [string]$TenantId,
+        [string]$BaseUrl,
+        [ValidateSet("Production", "Staging", "", IgnoreCase=$true)]
+        [string]$Slot,
+        [string]$CloudServiceName
+    )
+
+    if ($Slot -eq "Staging")
     {
-        Write-Host "Logging into Azure as service principal."
+        # Use Azure PowerShell cmdlets to find the URL of the staging slot.
+        Try
+        {
+            Write-Host "Logging into Azure as service principal."
 
-        $login = Add-AzureRmAccount `
-            -ApplicationId $ApplicationId `
-            -CertificateThumbprint $AzureCertificateThumbprint `
-            -ServicePrincipal `
-            -SubscriptionId $SubscriptionId `
-            -TenantId $TenantId
+            $login = Add-AzureRmAccount `
+                -ApplicationId $ApplicationId `
+                -CertificateThumbprint $AzureCertificateThumbprint `
+                -ServicePrincipal `
+                -SubscriptionId $SubscriptionId `
+                -TenantId $TenantId
 
-        Write-Host "Finding cloud service resource '$CloudServiceName'."
-        $resourceGroupName = (Find-AzureRmResource -ResourceNameEquals $CloudServiceName).ResourceGroupName
+            Write-Host "Finding cloud service resource '$CloudServiceName'."
+            $resourceGroupName = (Find-AzureRmResource -ResourceNameEquals $CloudServiceName).ResourceGroupName
 
-        Write-Host "Get cloud service resource details for slot '$Slot'."
-        $slotResource = Get-AzureRmResource `
-            -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
-        
-        $GalleryBaseUrl = ($slotResource.Properties.uri).Replace("http", "https")
+            Write-Host "Get cloud service resource details for slot '$Slot'."
+            $slotResource = Get-AzureRmResource `
+                -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
+            
+            $BaseUrl = ($slotResource.Properties.uri).Replace("http", "https")
+        }
+        Catch [System.Exception]
+        {
+            Write-Host "Failed to retrieve URL for testing!"
+            Write-Host $_.Exception.Message
+            Exit 1
+        }
     }
-    Catch [System.Exception]
-    {
-        Write-Host "Failed to retrieve URL for testing!"
-        Write-Host $_.Exception.Message
-        Exit 1
-    }
+
+    return $BaseUrl
 }
+
+$GalleryBaseUrl = Get-BaseUrl `
+    -ApplicationId $ApplicationId `
+    -AzureCertificateThumbprint $AzureCertificateThumbprint `
+    -SubscriptionId $SubscriptionId `
+    -TenantId $TenantId `
+    -BaseUrl $GalleryBaseUrl `
+    -Slot $GallerySlot `
+    -CloudServiceName $GalleryCloudServiceName
 
 Write-Host "Using the following GalleryBaseUrl: $GalleryBaseUrl" 
 $env:GalleryBaseUrl = $GalleryBaseUrl

--- a/src/NuGet.Services.EndToEnd/BasicTests.cs
+++ b/src/NuGet.Services.EndToEnd/BasicTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace NuGet.Services.EndToEnd
 {
-    public class BasicTests
+    public class BasicTests : IClassFixture<TrustedHttpsCertificatesFixture>
     {
         [Fact]
         public async Task NuGetDotOrgIsReachableOverHttps()
@@ -20,4 +20,5 @@ namespace NuGet.Services.EndToEnd
             }
         }
     }
+
 }

--- a/src/NuGet.Services.EndToEnd/BasicTests.cs
+++ b/src/NuGet.Services.EndToEnd/BasicTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.Services.EndToEnd
         public async Task NuGetDotOrgIsReachableOverHttps()
         {
             using (var httpClient = new HttpClient())
-            using (var response = await httpClient.GetAsync("https://www.nuget.org/"))
+            using (var response = await httpClient.GetAsync(EnvironmentSettings.GalleryBaseUrl))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }

--- a/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
+++ b/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
@@ -6,6 +6,11 @@ using System.Linq;
 
 namespace NuGet.Services.EndToEnd
 {
+    /// <summary>
+    /// This code duplicates some existing infrastructure in gallery's functional test suite. It should be
+    /// consolidated at some point.
+    /// https://github.com/NuGet/NuGetGallery/blob/master/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+    /// </summary>
     public static class EnvironmentSettings
     {
         private static EnvironmentVariableTarget[] Targets = new[]
@@ -21,13 +26,13 @@ namespace NuGet.Services.EndToEnd
         {
             get
             {
-                var value = GetEnvironmentVariable("TrustedHttpsCertificates", required: false);
-                if (value == null)
+                var fingerprints = GetEnvironmentVariable("TrustedHttpsCertificates", required: false);
+                if (fingerprints == null)
                 {
                     return new string[0];
                 }
                 
-                return value
+                return fingerprints
                     .Split(',')
                     .Select(p => p.Trim())
                     .Where(p => p.Length > 0)

--- a/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
+++ b/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace NuGet.Services.EndToEnd
+{
+    public static class EnvironmentSettings
+    {
+        private static EnvironmentVariableTarget[] Targets = new[]
+        {
+            EnvironmentVariableTarget.Process,
+            EnvironmentVariableTarget.User,
+            EnvironmentVariableTarget.Machine
+        };
+
+        public static string GalleryBaseUrl => GetEnvironmentVariable("GalleryBaseUrl");
+
+        private static string GetEnvironmentVariable(string key)
+        {
+            var output = Targets
+                .Select(target => Environment.GetEnvironmentVariable(key, target))
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+            if (output == null)
+            {
+                throw new ArgumentException($"The environment variable '{key}' is not defined.");
+            }
+
+            return output;
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
+++ b/src/NuGet.Services.EndToEnd/EnvironmentSettings.cs
@@ -15,15 +15,33 @@ namespace NuGet.Services.EndToEnd
             EnvironmentVariableTarget.Machine
         };
 
-        public static string GalleryBaseUrl => GetEnvironmentVariable("GalleryBaseUrl");
+        public static string GalleryBaseUrl => GetEnvironmentVariable("GalleryBaseUrl", required: true);
 
-        private static string GetEnvironmentVariable(string key)
+        public static string[] TrustedHttpsCertificates
+        {
+            get
+            {
+                var value = GetEnvironmentVariable("TrustedHttpsCertificates", required: false);
+                if (value == null)
+                {
+                    return new string[0];
+                }
+                
+                return value
+                    .Split(',')
+                    .Select(p => p.Trim())
+                    .Where(p => p.Length > 0)
+                    .ToArray();
+            }
+        }
+
+        private static string GetEnvironmentVariable(string key, bool required)
         {
             var output = Targets
                 .Select(target => Environment.GetEnvironmentVariable(key, target))
                 .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 
-            if (output == null)
+            if (required && output == null)
             {
                 throw new ArgumentException($"The environment variable '{key}' is not defined.");
             }

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -44,6 +44,7 @@
     <Compile Include="EnvironmentSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="TrustedHttpsCertificatesFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />
+    <Compile Include="EnvironmentSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>

--- a/src/NuGet.Services.EndToEnd/TrustedHttpsCertificatesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/TrustedHttpsCertificatesFixture.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Services.EndToEnd
+{
+    public class TrustedHttpsCertificatesFixture : IDisposable
+    {
+        public TrustedHttpsCertificatesFixture()
+        {
+
+        }
+
+        private static bool ServerCertificateValidationCallback(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None)
+            {
+                return true;
+            }
+
+            // If the only SSL error is name mismatch and the HTTPS certificate's thumbprint is in the
+            // list of trusted certificates, allow the certificate validation to pass.
+            var x509certificate2 = certificate as X509Certificate2;
+            if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch &&
+                x509certificate2 != null &&
+                EnvironmentSettings.TrustedHttpsCertificates.Contains(x509certificate2.Thumbprint, StringComparer.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/NuGet.Services.EndToEnd/TrustedHttpsCertificatesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/TrustedHttpsCertificatesFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
@@ -12,7 +13,7 @@ namespace NuGet.Services.EndToEnd
     {
         public TrustedHttpsCertificatesFixture()
         {
-
+            ServicePointManager.ServerCertificateValidationCallback += ServerCertificateValidationCallback;
         }
 
         private static bool ServerCertificateValidationCallback(
@@ -41,7 +42,7 @@ namespace NuGet.Services.EndToEnd
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            ServicePointManager.ServerCertificateValidationCallback -= ServerCertificateValidationCallback;
         }
     }
 


### PR DESCRIPTION
This mimics the script used in functional tests to allow running end-to-end tests against the gallery staging slot URL.

The parameters values live in Octopus and are passed to a VSTS build.