### PR TITLE
Aggressively push end-to-end test packages to minimize test run time

### DIFF
--- a/NuGet.Services.EndToEnd.sln
+++ b/NuGet.Services.EndToEnd.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26411.1
+VisualStudioVersion = 15.0.26424.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D505F569-4DF7-42EE-BAA0-472FEC55B28F}"
 EndProject
@@ -22,6 +22,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		test.ps1 = test.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{E8BAB621-E8D9-4994-BE47-F63B74C76927}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.EndToEnd.Test", "test\NuGet.Services.EndToEnd.Test\NuGet.Services.EndToEnd.Test.csproj", "{B69317BE-FA10-4458-A083-D9CECDABD61D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,11 +36,16 @@ Global
 		{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B69317BE-FA10-4458-A083-D9CECDABD61D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B69317BE-FA10-4458-A083-D9CECDABD61D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B69317BE-FA10-4458-A083-D9CECDABD61D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B69317BE-FA10-4458-A083-D9CECDABD61D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F} = {D505F569-4DF7-42EE-BAA0-472FEC55B28F}
+		{B69317BE-FA10-4458-A083-D9CECDABD61D} = {E8BAB621-E8D9-4994-BE47-F63B74C76927}
 	EndGlobalSection
 EndGlobal

--- a/build.ps1
+++ b/build.ps1
@@ -55,7 +55,8 @@ Invoke-BuildStep 'Restoring solution packages' { `
 
 Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' {
         $Paths = `
-            (Join-Path $PSScriptRoot "src\NuGet.Services.EndToEnd\Properties\AssemblyInfo.g.cs")
+            (Join-Path $PSScriptRoot "src\NuGet.Services.EndToEnd\Properties\AssemblyInfo.g.cs"),
+            (Join-Path $PSScriptRoot "test\NuGet.Services.EndToEnd.Test\Properties\AssemblyInfo.g.cs")
 
         Foreach ($Path in $Paths) {
             Set-VersionInfo -Path $Path -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'ed0316f287f23a48b0b9b7909eadd62b0c73aa73'
+    [string]$BuildBranch = '37ff6e758c38b3f513af39f881399ce85f4ff20b'
 )
 
 # For TeamCity - If any issue occurs, this script fail the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail

--- a/buildandtest.ps1
+++ b/buildandtest.ps1
@@ -8,10 +8,11 @@ param (
     [string]$SimpleVersion = '1.0.0',
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
-    [string]$CommitSHA
+    [string]$CommitSHA,
+    [switch]$OnlyUnitTests
 )
 
 $ScriptPath = Split-Path $MyInvocation.InvocationName
 
 & "$ScriptPath\build.ps1" -Configuration $Configuration -BuildNumber $BuildNumber -SkipRestore:$SkipRestore -CleanCache:$CleanCache -SimpleVersion "$SimpleVersion" -SemanticVersion "$SemanticVersion" -Branch "$Branch" -CommitSHA "$CommitSHA"
-& "$ScriptPath\test.ps1" -Configuration $Configuration -BuildNumber $BuildNumber
+& "$ScriptPath\test.ps1" -Configuration $Configuration -BuildNumber $BuildNumber -OnlyUnitTests:$OnlyUnitTests

--- a/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
+++ b/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
@@ -14,9 +14,11 @@ namespace NuGet.Services.EndToEnd
     {
         private readonly Clients _clients;
         private readonly ITestOutputHelper _logger;
+        private readonly TestSettings _testSettings;
 
         public ConnectivityTests(ITestOutputHelper logger)
         {
+            _testSettings = TestSettings.CreateFromEnvironment();
             _clients = Clients.Initialize();
             _logger = logger;
         }
@@ -25,7 +27,7 @@ namespace NuGet.Services.EndToEnd
         public async Task GalleryIsReachable()
         {
             using (var httpClient = new HttpClient())
-            using (var response = await httpClient.GetAsync(EnvironmentSettings.GalleryBaseUrl))
+            using (var response = await httpClient.GetAsync(_testSettings.GalleryBaseUrl))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
@@ -35,7 +37,7 @@ namespace NuGet.Services.EndToEnd
         public async Task V3IndexIsReachable()
         {
             using (var httpClient = new HttpClient())
-            using (var response = await httpClient.GetAsync(EnvironmentSettings.V3IndexUrl))
+            using (var response = await httpClient.GetAsync(_testSettings.V3IndexUrl))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }

--- a/src/NuGet.Services.EndToEnd/PushTests.cs
+++ b/src/NuGet.Services.EndToEnd/PushTests.cs
@@ -69,11 +69,11 @@ namespace NuGet.Services.EndToEnd
 
             foreach (var searchBaseAddress in searchBaseAddresses)
             {
-                var shouldBeEmptyV3 = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=packageid:{package.Id}&prerelease=true");
-                var shouldBeEmptyAutocomplete = await _clients.V3Search.AutocompleteAsync(searchBaseAddress, $"q=packageid:{package.Id}");
+                var shouldBeEmptyV3 = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=packageid:{package.Id}&prerelease=true", _logger);
+                var shouldBeEmptyAutocomplete = await _clients.V3Search.AutocompleteAsync(searchBaseAddress, $"q=packageid:{package.Id}", _logger);
 
-                var shouldNotBeEmptyV3 = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=packageid:{package.Id}&semVerLevel=2.0.0&prerelease=true");
-                var shouldNotBeEmptyAutocomplete = await _clients.V3Search.AutocompleteAsync(searchBaseAddress, $"q={package.Id}&semVerLevel=2.0.0");
+                var shouldNotBeEmptyV3 = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=packageid:{package.Id}&semVerLevel=2.0.0&prerelease=true", _logger);
+                var shouldNotBeEmptyAutocomplete = await _clients.V3Search.AutocompleteAsync(searchBaseAddress, $"q={package.Id}&semVerLevel=2.0.0", _logger);
 
                 // Assert
                 Assert.Equal(0, shouldBeEmptyV3.Data.Count);

--- a/src/NuGet.Services.EndToEnd/SearchResultTests.cs
+++ b/src/NuGet.Services.EndToEnd/SearchResultTests.cs
@@ -43,8 +43,8 @@ namespace NuGet.Services.EndToEnd
             foreach (var searchBaseAddress in searchBaseAddresses)
             {
                 // Act
-                var semVer1Query = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=");
-                var semVer2Query = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=&semVerLevel=2.0.0");
+                var semVer1Query = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=", _logger);
+                var semVer2Query = await _clients.V3Search.QueryAsync(searchBaseAddress, $"q=&semVerLevel=2.0.0", _logger);
 
                 // Assert
                 Assert.True(semVer1Query.Data.Count > 0);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -8,8 +8,8 @@ namespace NuGet.Services.EndToEnd.Support
     /// </summary>
     public class Clients
     {
-        private Clients(
-            GalleryClient gallery,
+        public Clients(
+            IGalleryClient gallery,
             V3IndexClient v3Index,
             V3SearchClient v3Search,
             FlatContainerClient flatContainer,
@@ -22,7 +22,7 @@ namespace NuGet.Services.EndToEnd.Support
             Registration = registration;
         }
 
-        public GalleryClient Gallery { get; }
+        public IGalleryClient Gallery { get; }
         public V3IndexClient V3Index { get; }
         public V3SearchClient V3Search { get; }
         public FlatContainerClient FlatContainer { get; }

--- a/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
@@ -59,7 +59,7 @@ namespace NuGet.Services.EndToEnd.Support
             var found = false;
             do
             {
-                var response = await _httpClient.GetJsonAsync<FlatContainerIndexResponse>(url, allowNotFound: true);
+                var response = await _httpClient.GetJsonAsync<FlatContainerIndexResponse>(url, allowNotFound: true, logger: null);
                 if (response != null)
                 {
                     found = response.Versions.Contains(version.ToLowerInvariant());

--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.EndToEnd.Support
     /// <summary>
     /// A simple interface for interacting with the gallery.
     /// </summary>
-    public class GalleryClient
+    public class GalleryClient : IGalleryClient
     {
         private readonly TestSettings _testSettings;
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public interface IGalleryClient
+    {
+        Task PushAsync(Stream nupkgStream);
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
@@ -63,7 +63,7 @@ namespace NuGet.Services.EndToEnd.Support
                 // pages. This is acceptable right now because the test packages never have more than 64 versions, which
                 // is the threshold that catalog2registration uses when deciding whether to break the registration index
                 // into pages.
-                var response = await _httpClient.GetJsonAsync<RegistrationIndexResponse>(url, allowNotFound: true);
+                var response = await _httpClient.GetJsonAsync<RegistrationIndexResponse>(url, allowNotFound: true, logger: null);
                 if (response != null)
                 {
                     found = response

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -25,25 +25,18 @@ namespace NuGet.Services.EndToEnd.Support
             _testSettings = testSettings;
         }
 
-        public async Task<V2SearchResponse> SearchQueryAsync(string searchBaseUrl, string queryString)
-        {
-            var baseUri = new Uri(searchBaseUrl);
-            var queryUrl = new Uri(baseUri, $"search/query?{queryString}");
-            return await _httpClient.GetJsonAsync<V2SearchResponse>(queryUrl.AbsoluteUri);
-        }
-
-        public async Task<V3SearchResponse> QueryAsync(string searchBaseUrl, string queryString)
+        public async Task<V3SearchResponse> QueryAsync(string searchBaseUrl, string queryString, ITestOutputHelper logger)
         {
             var baseUri = new Uri(searchBaseUrl);
             var queryUrl = new Uri(baseUri, $"query?{queryString}");
-            return await _httpClient.GetJsonAsync<V3SearchResponse>(queryUrl.AbsoluteUri);
+            return await _httpClient.GetJsonAsync<V3SearchResponse>(queryUrl.AbsoluteUri, logger);
         }
 
-        public async Task<AutocompleteResponse> AutocompleteAsync(string searchBaseUrl, string queryString)
+        public async Task<AutocompleteResponse> AutocompleteAsync(string searchBaseUrl, string queryString, ITestOutputHelper logger)
         {
             var baseUri = new Uri(searchBaseUrl);
             var queryUrl = new Uri(baseUri, $"autocomplete?{queryString}");
-            return await _httpClient.GetJsonAsync<AutocompleteResponse>(queryUrl.AbsoluteUri);
+            return await _httpClient.GetJsonAsync<AutocompleteResponse>(queryUrl.AbsoluteUri, logger);
         }
 
         /// <summary>
@@ -110,7 +103,7 @@ namespace NuGet.Services.EndToEnd.Support
             var found = false;
             do
             {
-                var response = await _httpClient.GetJsonAsync<V2SearchResponse>(url);
+                var response = await _httpClient.GetJsonAsync<V2SearchResponse>(url, logger: null);
                 found = response
                     .Data
                     .Where(d => d.PackageRegistration?.Id == id && d.Version == version)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
@@ -64,7 +64,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         private async Task<V3Index> GetV3IndexAsync()
         {
-            return await _httpClient.GetJsonAsync<V3Index>(_testSettings.V3IndexUrl);
+            return await _httpClient.GetJsonAsync<V3Index>(_testSettings.V3IndexUrl, logger: null);
         }
 
         private class V3Index

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -11,74 +11,167 @@ using Xunit.Abstractions;
 
 namespace NuGet.Services.EndToEnd.Support
 {
+    /// <summary>
+    /// A test fixture for sharing pushed packages between tests. Since packages take quite a while (minutes) to make
+    /// their way through the V3 pipeline, packages should be pushed all at once and shared between tests, if possible.
+    /// </summary>
     public class PushedPackagesFixture : IDisposable
     {
-        private readonly object _packagesLock;
-        private readonly IDictionary<PackageType, PushedPackage> _packages;
+        private static readonly HashSet<PackageType> SemVer2PackageTypes = new HashSet<PackageType>
+        {
+            PackageType.SemVer2Prerelease,
+        };
+
+        private readonly SemaphoreSlim _pushLock;
+        private readonly object _packagesLock = new object();
+        private readonly IDictionary<PackageType, Package> _packages;
         private readonly Clients _clients;
+        private readonly TestSettings _testSettings;
 
         public PushedPackagesFixture()
         {
             _clients = Clients.Initialize();
-            _packagesLock = new object();
-            _packages = new Dictionary<PackageType, PushedPackage>();
+            _testSettings = TestSettings.CreateFromEnvironment();
+            _pushLock = new SemaphoreSlim(initialCount: 1);
+            _packages = new Dictionary<PackageType, Package>();
         }
         
-        public async Task<Package> PushAsync(PackageType packageType, ITestOutputHelper logger)
+        public async Task<Package> PushAsync(PackageType requestedPackageType, ITestOutputHelper logger)
         {
-            PushedPackage pushedPackage;
-            lock (_packagesLock)
+            var pushedPackage = GetPushedPackage(requestedPackageType, logger);
+            if (pushedPackage != null)
             {
-                if (!_packages.TryGetValue(packageType, out pushedPackage))
-                {
-                    var package = CreatePackage(packageType);
-                    pushedPackage = new PushedPackage(package);
-                    _packages[packageType] = pushedPackage;
-                }
+                return pushedPackage;
             }
 
-            if (pushedPackage.Pushed)
-            {
-                logger.WriteLine($"Package {pushedPackage} push has already been pushed.");
-                return pushedPackage.Package;
-            }
+            return await PushUnpushedPackagesAsync(requestedPackageType, logger);
+        }
 
-            var acquired = await pushedPackage.PushLock.WaitAsync(0);
+        private async Task<Package> PushUnpushedPackagesAsync(PackageType requestedPackageType, ITestOutputHelper logger)
+        {
+            var acquired = await _pushLock.WaitAsync(0);
             try
             {
                 if (!acquired)
                 {
-                    logger.WriteLine($"Another test is already pushing {pushedPackage}. Waiting.");
-                    await pushedPackage.PushLock.WaitAsync();
-                    acquired = true;
+                    logger.WriteLine("Another test is already pushing the packages. Waiting.");
+                    await _pushLock.WaitAsync();
                 }
 
-                if (pushedPackage.Pushed)
+                // Has the package already been pushed?
+                var pushedPackage = GetPushedPackage(requestedPackageType, logger);
+                if (pushedPackage != null)
                 {
-                    logger.WriteLine($"Package {pushedPackage} has already been pushed.");
-                    return pushedPackage.Package;
+                    return pushedPackage;
                 }
 
-                using (var packageStream = new MemoryStream(pushedPackage.Package.NupkgBytes.ToArray()))
+                var packageTypes = GetPackageTypes(requestedPackageType);
+
+                // Push all of the package types that have not been pushed yet.
+                var pushTasks = new Dictionary<PackageType, Task<Package>>();
+                foreach (var packageType in packageTypes)
                 {
-                    logger.WriteLine($"Package {pushedPackage} is about to be pushed.");
-                    await _clients.Gallery.PushAsync(packageStream);
-                    logger.WriteLine($"Package {pushedPackage} has been successfully pushed.");
-                    pushedPackage.MarkAsPushed();
-                    return pushedPackage.Package;
+                    if (!_packages.TryGetValue(packageType, out Package package))
+                    {
+                        pushTasks.Add(packageType, UncachedPushAsync(requestedPackageType, packageType, logger));
+                    }
                 }
+
+                await Task.WhenAll(pushTasks.Values);
+
+                // Add the pushed packages to the cache.
+                lock (_packagesLock)
+                {
+                    foreach (var packageType in pushTasks.Keys)
+                    {
+                        var result = pushTasks[packageType].Result;
+                        if (result != null)
+                        {
+                            _packages[packageType] = result;
+                        }
+                    }
+                }
+
+                // Use the package that we just pushed.
+                return _packages[requestedPackageType];
             }
             finally
             {
                 if (acquired)
                 {
-                    pushedPackage.PushLock.Release();
+                    _pushLock.Release();
                 }
             }
         }
 
+        private Package GetPushedPackage(PackageType requestedPackageType, ITestOutputHelper logger)
+        {
+            lock (_packagesLock)
+            {
+                if (_packages.TryGetValue(requestedPackageType, out Package package))
+                {
+                    logger.WriteLine($"Package of type {requestedPackageType} has already been pushed. Using {package}.");
+                    return package;
+                }
+            }
+
+            return null;
+        }
+
+        private async Task<Package> UncachedPushAsync(PackageType requestedPackageType, PackageType packageType, ITestOutputHelper logger)
+        {
+            await Task.Yield();
+
+            Package package = CreatePackage(packageType);
+            logger.WriteLine($"Package of type {packageType} has not been pushed yet. Pushing {package}.");
+            try
+            {
+                using (var nupkgStream = new MemoryStream(package.NupkgBytes.ToArray()))
+                {
+                    await _clients.Gallery.PushAsync(nupkgStream);
+                }
+                logger.WriteLine($"Package {package} has been pushed.");
+            }
+            catch (Exception ex)
+            {
+                if (packageType == requestedPackageType)
+                {
+                    throw;
+                }
+                else
+                {
+                    logger.WriteLine(
+                        $"The package {package} failed to be pushed. Since this package was not explicitly requested " +
+                        $"by the running test, this failure will be ignored. Exception:{Environment.NewLine}{ex}");
+                    return null;
+                }
+            }
+            
+            return package;
+        }
+
         public void Dispose()
         {
+        }
+
+        private IEnumerable<PackageType> GetPackageTypes(PackageType requestedPackageType)
+        {
+            var selectedPackageTypes = Enum
+                .GetValues(typeof(PackageType))
+                .Cast<PackageType>()
+                .Concat(new[] { requestedPackageType })
+                .Distinct()
+                .OrderBy(x => x)
+                .AsEnumerable();
+
+            // If SemVer 2.0.0 is not enabled, don't automatically push SemVer 2.0.0 packages.
+            if (!_testSettings.SemVer2Enabled)
+            {
+                selectedPackageTypes = selectedPackageTypes
+                    .Except(SemVer2PackageTypes);
+            }
+
+            return selectedPackageTypes;
         }
 
         private Package CreatePackage(PackageType packageType)
@@ -87,32 +180,9 @@ namespace NuGet.Services.EndToEnd.Support
             {
                 case PackageType.SemVer2Prerelease:
                     return Package.Create(packageType.ToString(), "1.0.0-alpha.1");
+                case PackageType.SemVer1Stable:
                 default:
                     return Package.Create(packageType.ToString(), "1.0.0");
-            }
-        }
-
-        private class PushedPackage
-        {
-            public PushedPackage(Package package)
-            {
-                PushLock = new SemaphoreSlim(1);
-                Package = package;
-                Pushed = false;
-            }
-
-            public SemaphoreSlim PushLock { get; }
-            public Package Package { get; }
-            public bool Pushed { get; private set; }
-
-            public override string ToString()
-            {
-                return Package.ToString();
-            }
-
-            public void MarkAsPushed()
-            {
-                Pushed = true;
             }
         }
     }

--- a/src/NuGet.Services.EndToEnd/Support/SemVer2FactAttribute.cs
+++ b/src/NuGet.Services.EndToEnd/Support/SemVer2FactAttribute.cs
@@ -13,7 +13,8 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public SemVer2FactAttribute()
         {
-            if (!EnvironmentSettings.SemVer2Enabled)
+            var testSettings = TestSettings.CreateFromEnvironment();
+            if (!testSettings.SemVer2Enabled)
             {
                 Skip = "SemVer 2.0.0 is not enabled. Set the SemVer2Enabled environment variable to true to enable this test.";
             }

--- a/test.ps1
+++ b/test.ps1
@@ -30,8 +30,8 @@ Function Run-Tests {
 	
 	$UnitTestAssemblies = @("test\NuGet.Services.EndToEnd.Test\bin\$Configuration\NuGet.Services.EndToEnd.Test.dll")
 
-    $AllTestAssemblies = @("src\NuGet.Services.EndToEnd\bin\$Configuration\NuGet.Services.EndToEnd.dll") `
-		+ $UnitTestAssemblies
+    $AllTestAssemblies = $UnitTestAssemblies + `
+		@("src\NuGet.Services.EndToEnd\bin\$Configuration\NuGet.Services.EndToEnd.dll") 
 
 	if ($OnlyUnitTests) {
 		$AllTestAssemblies = $UnitTestAssemblies

--- a/test.ps1
+++ b/test.ps1
@@ -27,7 +27,9 @@ Function Run-Tests {
 
     $xUnitExe = (Join-Path $PSScriptRoot "packages\xunit.runner.console.2.2.0\tools\xunit.console.exe")
 
-    $TestAssemblies = @("src\NuGet.Services.EndToEnd\bin\$Configuration\NuGet.Services.EndToEnd.dll")
+    $TestAssemblies = `
+		"src\NuGet.Services.EndToEnd\bin\$Configuration\NuGet.Services.EndToEnd.dll",
+		"test\NuGet.Services.EndToEnd.Test\bin\$Configuration\NuGet.Services.EndToEnd.Test.dll"
 
     $TestCount = 0
 

--- a/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
+++ b/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
@@ -4,12 +4,12 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{35CA0B78-DE1A-4C4E-A97F-85E84DB17A2F}</ProjectGuid>
+    <ProjectGuid>{B69317BE-FA10-4458-A083-D9CECDABD61D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Services.EndToEnd</RootNamespace>
-    <AssemblyName>NuGet.Services.EndToEnd</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AssemblyName>NuGet.Services.EndToEnd.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -40,34 +40,21 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ConnectivityTests.cs" />
-    <Compile Include="Support\Clients\Clients.cs" />
-    <Compile Include="Support\Clients\FlatContainerClient.cs" />
-    <Compile Include="Support\Clients\IGalleryClient.cs" />
-    <Compile Include="Support\Clients\RegistrationClient.cs" />
-    <Compile Include="Support\PackageType.cs" />
-    <Compile Include="Support\PushedPackagesCollection.cs" />
-    <Compile Include="Support\PushedPackagesFixture.cs" />
-    <Compile Include="Support\Clients\GalleryClient.cs" />
-    <Compile Include="Support\Package.cs" />
-    <Compile Include="Support\EnvironmentSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
-    <Compile Include="PushTests.cs" />
-    <Compile Include="Support\Clients\V3SearchClient.cs" />
-    <Compile Include="Support\Clients\SimpleHttpClient.cs" />
-    <Compile Include="Support\SemVer2FactAttribute.cs" />
-    <Compile Include="Support\TestSettings.cs" />
-    <Compile Include="Support\TrustedHttpsCertificatesFixture.cs" />
-    <Compile Include="Support\TestData.cs" />
-    <Compile Include="Support\TestDirectory.cs" />
-    <Compile Include="Support\Clients\V3IndexClient.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Compile Include="Support\PushedPackagesFixtureTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.EndToEnd\NuGet.Services.EndToEnd.csproj">
+      <Project>{35ca0b78-de1a-4c4e-a97f-85e84db17a2f}</Project>
+      <Name>NuGet.Services.EndToEnd</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/NuGet.Services.EndToEnd.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.Services.EndToEnd.Test")]
+[assembly: ComVisible(false)]
+[assembly: Guid("b69317be-fa10-4458-a083-d9cecdabd61d")]

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTest.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTest.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class PushedPackagesFixtureTest
+    {
+        private readonly Mock<IGalleryClient> _galleryClient;
+        private readonly TestSettings _testSettings;
+        private readonly PushedPackagesFixture _fixture;
+        private readonly Mock<ITestOutputHelper> _logger;
+
+        public PushedPackagesFixtureTest()
+        {
+            _galleryClient = new Mock<IGalleryClient>();
+            _testSettings = new TestSettings(
+                galleryBaseUrl: "https://example-gallery",
+                v3IndexUrl: "https://example-v3/index.json",
+                trustedHttpsCertificates: new List<string>(),
+                apiKey: "API_KEY",
+                searchBaseUrl: null,
+                semVer2Enabled: true);
+            _fixture = new PushedPackagesFixture(_galleryClient.Object, _testSettings);
+            _logger = new Mock<ITestOutputHelper>();
+        }
+
+        [Theory]
+        [InlineData(PackageType.SemVer1Stable, "E2E." + nameof(PackageType.SemVer1Stable) + ".", "1.0.0")]
+        [InlineData(PackageType.SemVer2Prerelease, "E2E." + nameof(PackageType.SemVer2Prerelease) + ".", "1.0.0-alpha.1")]
+        public async Task ProducesExpectedPackage(PackageType packageType, string idPrefix, string version)
+        {
+            // Act
+            var package = await _fixture.PushAsync(packageType, _logger.Object);
+
+            // Assert
+            Assert.StartsWith(idPrefix, package.Id);
+            Assert.Equal(version, package.Version);
+        }
+
+        [Fact]
+        public async Task PushesAllPackagesOnFirstPush()
+        {
+            // Act
+            await _fixture.PushAsync(PackageType.SemVer1Stable, _logger.Object);
+
+            // Assert
+            _galleryClient.Verify(
+                x => x.PushAsync(It.IsAny<Stream>()),
+                Times.Exactly(Enum.GetNames(typeof(PackageType)).Count()));
+        }
+
+        [Fact]
+        public async Task CachesPushedPackage()
+        {
+            // Act
+            var packageA = await _fixture.PushAsync(PackageType.SemVer1Stable, _logger.Object);
+            _galleryClient.Reset();
+            var packageB = await _fixture.PushAsync(PackageType.SemVer1Stable, _logger.Object);
+
+            // Assert
+            Assert.Same(packageA, packageB);
+            _galleryClient.Verify(
+                x => x.PushAsync(It.IsAny<Stream>()),
+                Times.Never); // "never" because we reset the mock
+        }
+
+        [Fact]
+        public async Task CanPushUnnamedPackageType()
+        {
+            // Arrange
+            await _fixture.PushAsync(PackageType.SemVer1Stable, _logger.Object);
+            _galleryClient.Reset();
+
+            // Act
+            var package = await _fixture.PushAsync((PackageType) 999, _logger.Object);
+
+            // Assert
+            Assert.NotNull(package);
+            Assert.StartsWith("E2E.999.", package.Id);
+            Assert.Equal("1.0.0", package.Version);
+            _galleryClient.Verify(
+                x => x.PushAsync(It.IsAny<Stream>()),
+                Times.Once);
+        }
+    }
+}

--- a/test/NuGet.Services.EndToEnd.Test/project.json
+++ b/test/NuGet.Services.EndToEnd.Test/project.json
@@ -1,0 +1,12 @@
+﻿{
+  "dependencies": {
+    "Moq": "4.7.8",
+    "xunit": "2.2.0"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}


### PR DESCRIPTION
If end-to-end tests need N packages total and the first test is running, push all N packages instead of just the one that the test needs. This means they will all start flowing through V3 at the same time and subsequent tests won't have to wait long for the package to be available.