### PR TITLE
Use the default push timeout that client uses

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -27,6 +28,9 @@ namespace NuGet.Services.EndToEnd.Support
             using (var httpClient = new HttpClient())
             using (var request = new HttpRequestMessage(HttpMethod.Put, url))
             {
+                // Use the default push timeout that the client uses.
+                httpClient.Timeout = TimeSpan.FromMinutes(5);
+
                 request.Headers.Add(ApiKeyHeader, _testSettings.ApiKey);
                 request.Content = new StreamContent(nupkgStream);
 

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -149,7 +149,7 @@ namespace NuGet.Services.EndToEnd.Support
             }
             catch (Exception ex)
             {
-                if (packageType == requestedPackageType)
+                if (packageType == requestedPackageType || ex is TaskCanceledException)
                 {
                     throw;
                 }


### PR DESCRIPTION
Allow more time for pushing (use the default value used by the client: 5 minutes).

Don't swallow `TaskCanceledException` when pushing since this can lead to a 409 later.