### PR TITLE
Need retry logic for WaitForPackageAsync in E2E clients

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/SimpleHttpClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SimpleHttpClient.cs
@@ -18,6 +18,7 @@ namespace NuGet.Services.EndToEnd.Support
     public class SimpleHttpClient
     {
         private const int MaxRetries = 3;
+        private const int RetryDelayInMilliseconds = 500;
 
         public Task<T> GetJsonAsync<T>(string url, ITestOutputHelper logger)
         {
@@ -65,6 +66,7 @@ namespace NuGet.Services.EndToEnd.Support
                     {
                         throw;
                     }
+                    await Task.Delay(RetryDelayInMilliseconds);
                 }
             }
             while (true);


### PR DESCRIPTION
Multiple deployments of catalog2registration have failed due to SocketException at SimpleHttpClient.GetJsonAsync. We should add retry logic here.

See E2E builds: 10372, 10387, 10388

Opened issue at: https://github.com/NuGet/NuGetGallery/issues/4295