### PR TITLE
Shorten timeout of flat container and registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ This project contains end-to-end tests for NuGet.org and its internal services.
 
 End-to-end tests are meant to simulate customer scenarios and verify artifacts and results that customers care about.
 Testing of edge cases or implementation details should be done in component-specific functional or unit test suites.
+
+## Local Execution
+
+1. Create an account on the environment you wish to test.
+2. Create a new API key on this account.
+3. Modify `src\NuGet.Services.EndToEnd\Support\TestSettings.cs`:
+    1. Change the `CurrentMode` property to the environment you wish to target.
+    2. Inside of the `Create` method, find the instantiation of `TestSettings` that corresponds to the environment you wish to test.
+    Replace the `TestSetting`'s `"API_KEY"` string with the API key you created in step #2.

--- a/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
@@ -65,14 +65,14 @@ namespace NuGet.Services.EndToEnd.Support
                     found = response.Versions.Contains(version.ToLowerInvariant());
                 }
 
-                if (!found && duration.Elapsed + TestData.V3SleepDuration < TestData.V3WaitDuration)
+                if (!found && duration.Elapsed + TestData.V3SleepDuration < TestData.FlatContainerWaitDuration)
                 {
                     await Task.Delay(TestData.V3SleepDuration);
                 }
             }
-            while (!found && duration.Elapsed < TestData.V3WaitDuration);
+            while (!found && duration.Elapsed < TestData.FlatContainerWaitDuration);
 
-            Assert.True(found, $"Package {id} {version} was not found on {baseUrl} after waiting {TestData.V3WaitDuration}.");
+            Assert.True(found, $"Package {id} {version} was not found on {baseUrl} after waiting {TestData.FlatContainerWaitDuration}.");
             logger.WriteLine($"Package {id} {version} was found on {baseUrl} after waiting {duration.Elapsed}.");
         }
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
@@ -150,12 +150,12 @@ namespace NuGet.Services.EndToEnd.Support
                     complete = isComplete(response);
                 }
 
-                if (!complete && duration.Elapsed + TestData.V3SleepDuration < TestData.V3WaitDuration)
+                if (!complete && duration.Elapsed + TestData.V3SleepDuration < TestData.RegistrationWaitDuration)
                 {
                     await Task.Delay(TestData.V3SleepDuration);
                 }
             }
-            while (!complete && duration.Elapsed < TestData.V3WaitDuration);
+            while (!complete && duration.Elapsed < TestData.RegistrationWaitDuration);
 
             Assert.True(complete, string.Format(failureMessageFormat, baseUrl, duration.Elapsed));
             logger.WriteLine(string.Format(successMessageFormat, baseUrl, duration.Elapsed));

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -227,12 +227,12 @@ namespace NuGet.Services.EndToEnd.Support
                 var response = await _httpClient.GetJsonAsync<V2SearchResponse>(url, logger: null);
                 complete = isComplete(response);
 
-                if (!complete && duration.Elapsed + TestData.V3SleepDuration < TestData.V3WaitDuration)
+                if (!complete && duration.Elapsed + TestData.V3SleepDuration < TestData.SearchWaitDuration)
                 {
                     await Task.Delay(TestData.V3SleepDuration);
                 }
             }
-            while (!complete && duration.Elapsed < TestData.V3WaitDuration);
+            while (!complete && duration.Elapsed < TestData.SearchWaitDuration);
 
             Assert.True(complete, string.Format(failureMessageFormat, v2SearchUrl, duration.Elapsed));
             logger.WriteLine(string.Format(successMessageFormat, v2SearchUrl, duration.Elapsed));

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -12,6 +12,8 @@ namespace NuGet.Services.EndToEnd.Support
     public static class TestData
     {
         public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net40");
+        public static readonly TimeSpan FlatContainerWaitDuration = TimeSpan.FromMinutes(10);
+        public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(10);
         public static readonly TimeSpan V3WaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan V3SleepDuration = TimeSpan.FromSeconds(5);
 

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -12,9 +12,9 @@ namespace NuGet.Services.EndToEnd.Support
     public static class TestData
     {
         public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net40");
-        public static readonly TimeSpan FlatContainerWaitDuration = TimeSpan.FromMinutes(10);
-        public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(10);
-        public static readonly TimeSpan V3WaitDuration = TimeSpan.FromMinutes(20);
+        public static readonly TimeSpan FlatContainerWaitDuration = TimeSpan.FromMinutes(5);
+        public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(5);
+        public static readonly TimeSpan SearchWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan V3SleepDuration = TimeSpan.FromSeconds(5);
 
         public static Stream BuildPackageStream(PackageCreationContext context)


### PR DESCRIPTION
catalog2dnx and catalog2registration jobs do not need a long timeout like catalog2lucene. This shortens the timeout so that the tests fail faster in the error case.