### PR TITLE
Add retry around V2V3SearchClient polling and Azure Management API calls

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -42,6 +42,8 @@
   <ItemGroup>
     <Compile Include="AutocompleteResultTests.cs" />
     <Compile Include="Support\Clients\ClientHelper.cs" />
+    <Compile Include="Support\Clients\IRetryingAzureManagementAPIWrapper.cs" />
+    <Compile Include="Support\Clients\RetryingAzureManagementAPIWrapper.cs" />
     <Compile Include="Support\Clients\SearchServiceProperties.cs" />
     <Compile Include="Support\Clients\V3IndexClient.cs" />
     <Compile Include="Support\CommonCollection.cs" />
@@ -56,7 +58,9 @@
     <Compile Include="Support\Configuration\E2ESecretConfigurationReader.cs" />
     <Compile Include="Support\Configuration\GalleryConfiguration.cs" />
     <Compile Include="Support\Configuration\SearchServiceConfiguration.cs" />
+    <Compile Include="Support\ExceptionExtensions.cs" />
     <Compile Include="Support\PackageCreationContext.cs" />
+    <Compile Include="Support\RetryUtility.cs" />
     <Compile Include="Support\SourceType.cs" />
     <Compile Include="Support\CommandRunner.cs" />
     <Compile Include="Support\CommandRunnerResult.cs" />

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using NuGet.Services.AzureManagement;
 
@@ -88,11 +89,13 @@ namespace NuGet.Services.EndToEnd.Support
                 nuGetExe);
         }
 
-        private static IAzureManagementAPIWrapper GetAzureManagementAPIWrapper(TestSettings testSettings)
+        private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapper(TestSettings testSettings)
         {
             if (testSettings.AzureManagementAPIWrapperConfiguration != null)
             {
-                return new AzureManagementAPIWrapper(testSettings.AzureManagementAPIWrapperConfiguration);
+                return new RetryingAzureManagementAPIWrapper(
+                    new AzureManagementAPIWrapper(testSettings.AzureManagementAPIWrapperConfiguration),
+                    RetryUtility.DefaultSleepDuration);
             }
 
             return null;

--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -25,7 +25,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         private readonly SimpleHttpClient _httpClient;
         private readonly TestSettings _testSettings;
-        private readonly IAzureManagementAPIWrapper _azureManagementAPIWrapper;
+        private readonly IRetryingAzureManagementAPIWrapper _azureManagementAPIWrapper;
 
         private Uri _galleryUrl = null;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
@@ -65,6 +65,7 @@ namespace NuGet.Services.EndToEnd.Support
                                     serviceDetails.ResourceGroup,
                                     serviceDetails.Name,
                                     serviceDetails.Slot,
+                                    logger,
                                     CancellationToken.None);
 
                     var cloudService = AzureHelper.ParseCloudServiceProperties(result);
@@ -82,7 +83,7 @@ namespace NuGet.Services.EndToEnd.Support
             return _galleryUrl;
         }
 
-        public GalleryClient(SimpleHttpClient httpClient, TestSettings testSettings, IAzureManagementAPIWrapper azureManagementAPIWrapper)
+        public GalleryClient(SimpleHttpClient httpClient, TestSettings testSettings, IRetryingAzureManagementAPIWrapper azureManagementAPIWrapper)
         {
             _httpClient = httpClient;
             _testSettings = testSettings;

--- a/src/NuGet.Services.EndToEnd/Support/Clients/IRetryingAzureManagementAPIWrapper.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/IRetryingAzureManagementAPIWrapper.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public interface IRetryingAzureManagementAPIWrapper
+    {
+        Task<string> GetCloudServicePropertiesAsync(string subscription, string resourceGroup, string name, string slot, ITestOutputHelper logger, CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/Clients/RetryingAzureManagementAPIWrapper.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/RetryingAzureManagementAPIWrapper.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Services.AzureManagement;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class RetryingAzureManagementAPIWrapper : IRetryingAzureManagementAPIWrapper
+    {
+        private readonly IAzureManagementAPIWrapper _inner;
+        private readonly TimeSpan _sleepDuration;
+
+        public RetryingAzureManagementAPIWrapper(IAzureManagementAPIWrapper inner, TimeSpan sleepDuration)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _sleepDuration = sleepDuration;
+        }
+
+        public Task<string> GetCloudServicePropertiesAsync(
+            string subscription,
+            string resourceGroup,
+            string name,
+            string slot,
+            ITestOutputHelper logger,
+            CancellationToken token)
+        {
+            return RetryUtility.ExecuteWithRetry(
+                () => _inner.GetCloudServicePropertiesAsync(
+                    subscription,
+                    resourceGroup,
+                    name,
+                    slot,
+                    token),
+                ex => ex is AzureManagementException,
+                maxAttempts: RetryUtility.DefaultMaxAttempts,
+                sleepDuration: _sleepDuration,
+                logger: logger);
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/ExceptionExtensions.cs
+++ b/src/NuGet.Services.EndToEnd/Support/ExceptionExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public static class ExceptionExtensions
+    {
+        public static bool HasTypeOrInnerType<T>(this Exception ex)
+        {
+            var current = ex;
+            while (current != null)
+            {
+                if (current is T)
+                {
+                    return true;
+                }
+
+                current = current.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/RetryUtility.cs
+++ b/src/NuGet.Services.EndToEnd/Support/RetryUtility.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public static class RetryUtility
+    {
+        public const int DefaultMaxAttempts = 5;
+        public static readonly TimeSpan DefaultSleepDuration = TimeSpan.FromSeconds(30);
+
+        public static Task ExecuteWithRetry(
+            Func<Task> executeAsync,
+            Func<Exception, bool> shouldRetry,
+            ITestOutputHelper logger)
+        {
+            return ExecuteWithRetry(
+                executeAsync,
+                shouldRetry,
+                maxAttempts: DefaultMaxAttempts,
+                sleepDuration: DefaultSleepDuration,
+                logger: logger);
+        }
+
+        public static Task<T> ExecuteWithRetry<T>(
+            Func<Task<T>> executeAsync,
+            Func<Exception, bool> shouldRetry,
+            ITestOutputHelper logger)
+        {
+            return ExecuteWithRetry(
+                executeAsync,
+                shouldRetry,
+                maxAttempts: DefaultMaxAttempts,
+                sleepDuration: DefaultSleepDuration,
+                logger: logger);
+        }
+
+        public static Task ExecuteWithRetry(
+            Func<Task> executeAsync,
+            Func<Exception, bool> shouldRetry,
+            int maxAttempts,
+            TimeSpan sleepDuration,
+            ITestOutputHelper logger)
+        {
+            return ExecuteWithRetry(
+                async () =>
+                {
+                    await executeAsync();
+                    return 0;
+                },
+                shouldRetry,
+                maxAttempts,
+                sleepDuration,
+                logger: logger);
+        }
+
+        public static async Task<T> ExecuteWithRetry<T>(
+            Func<Task<T>> executeAsync,
+            Func<Exception, bool> shouldRetry,
+            int maxAttempts,
+            TimeSpan sleepDuration,
+            ITestOutputHelper logger)
+        {
+            var attempt = 0;
+            while (true)
+            {
+                if (attempt > 0)
+                {
+                    logger.WriteLine($"Sleeping for {sleepDuration} before trying again.");
+                    await Task.Delay(sleepDuration);
+                }
+
+                attempt++;
+
+                try
+                {
+                    var result = await executeAsync();
+                    if (attempt > 1)
+                    {
+                        logger.WriteLine($"Succeeded after {attempt} attempts.");
+                    }
+
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    if (attempt == maxAttempts || !shouldRetry(ex))
+                    {
+                        logger.WriteLine($"Failed after {attempt} attempts.");
+                        throw;
+                    }
+
+                    logger.WriteLine($"Exception encountered. Will retry. Exception:{Environment.NewLine}{ex}{Environment.NewLine}");
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
+++ b/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
@@ -41,7 +41,10 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="Support\ExceptionExtensionsTests.cs" />
     <Compile Include="Support\PushedPackagesFixtureTests.cs" />
+    <Compile Include="Support\RetryingAzureManagementAPIWrapperTests.cs" />
+    <Compile Include="Support\RetryUtilityTests.cs" />
     <Compile Include="Support\TestSettingsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/NuGet.Services.EndToEnd.Test/Support/ExceptionExtensionsTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/ExceptionExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using Xunit;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class ExceptionExtensionsTests
+    {
+        public class HasTypeOrInnerType
+        {
+            [Fact]
+            public void ReturnsTrueWhenExceptionItselfMatchesType()
+            {
+                var target = new InvalidOperationException(
+                    "bad!",
+                    new ApplicationException("something else"));
+
+                Assert.True(target.HasTypeOrInnerType<InvalidOperationException>());
+            }
+
+            [Fact]
+            public void ReturnsTrueWhenInnerExceptionMatchesType()
+            {
+                var target = new ApplicationException(
+                    "bad!",
+                    new InvalidOperationException("something else"));
+
+                Assert.True(target.HasTypeOrInnerType<InvalidOperationException>());
+            }
+
+            [Fact]
+            public void ReturnsTrueWhenInnerInnerExceptionMatchesType()
+            {
+                var target = new HttpRequestException(
+                    "An error occurred while sending the request.",
+                    new WebException(
+                        "Unable to connect to the remote server",
+                        new SocketException(10060)));
+
+                Assert.True(target.HasTypeOrInnerType<SocketException>());
+            }
+
+            [Fact]
+            public void ReturnsTrueWhenInnerInnerExceptionInheritsType()
+            {
+                var target = new HttpRequestException(
+                    "An error occurred while sending the request.",
+                    new WebException(
+                        "Unable to connect to the remote server",
+                        new SocketException(10060)));
+
+                Assert.True(target.HasTypeOrInnerType<InvalidOperationException>());
+            }
+
+            [Fact]
+            public void ReturnsFalseWhenNoExceptionMatchesType()
+            {
+                var target = new HttpRequestException(
+                    "An error occurred while sending the request.",
+                    new WebException(
+                        "Unable to connect to the remote server",
+                        new SocketException(10060)));
+
+                Assert.False(target.HasTypeOrInnerType<ApplicationException>());
+            }
+        }
+    }
+}

--- a/test/NuGet.Services.EndToEnd.Test/Support/RetryUtilityTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/RetryUtilityTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class RetryUtilityTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public RetryUtilityTests(ITestOutputHelper output)
+        {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+        }
+
+        [Fact]
+        public async Task DoesNotRetryIfNoExceptionIsThrown()
+        {
+            var attempts = 0;
+            Func<Task<int>> executeAsync = () => Task.Run(() =>
+            {
+                attempts++;
+                return Task.FromResult(23);
+            });
+
+            var result = await RetryUtility.ExecuteWithRetry(
+                executeAsync,
+                ex => true,
+                _output);
+
+            Assert.Equal(1, attempts);
+            Assert.Equal(23, result);
+        }
+
+        [Fact]
+        public async Task TriesUpToMaxAttemptsTimes()
+        {
+            var attempts = 0;
+            Func<Task<int>> executeAsync = () => Task.Run<int>(async () =>
+            {
+                attempts++;
+                await Task.Yield();
+                throw new InvalidOperationException("Bad! " + attempts);
+            });
+
+            var actualEx = await Assert.ThrowsAsync<InvalidOperationException>(() => RetryUtility.ExecuteWithRetry(
+                executeAsync,
+                ex => true,
+                maxAttempts: 5,
+                sleepDuration: TimeSpan.Zero,
+                logger: _output));
+
+            Assert.Equal(5, attempts);
+            Assert.Equal(actualEx.Message, "Bad! 5");
+        }
+
+        [Fact]
+        public async Task SleepsSleepDurationBetweenAttempts()
+        {
+            var minimum = TimeSpan.FromMilliseconds(400);
+            Func<Task<int>> executeAsync = () => Task.Run<int>(async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("Bad!");
+            });
+
+            var stopwatch = Stopwatch.StartNew();
+            var actualEx = await Assert.ThrowsAsync<InvalidOperationException>(() => RetryUtility.ExecuteWithRetry(
+                executeAsync,
+                ex => true,
+                maxAttempts: 5,
+                sleepDuration: TimeSpan.FromMilliseconds(100),
+                logger: _output));
+            stopwatch.Stop();
+
+            Assert.True(
+                stopwatch.Elapsed >= minimum,
+                $"Elapsed was {stopwatch.Elapsed}. Should be greater than or equal to {minimum}.");
+            Assert.Equal(actualEx.Message, "Bad!");
+        }
+
+        [Fact]
+        public async Task ReturnsResultAfterSomeRetries()
+        {
+            var attempts = 0;
+            Func<Task<int>> executeAsync = () => Task.Run(async () =>
+            {
+                attempts++;
+                if (attempts > 3)
+                {
+                    return 23;
+                }
+
+                await Task.Yield();
+                throw new InvalidOperationException("Bad! " + attempts);
+            });
+
+            var result = await RetryUtility.ExecuteWithRetry(
+                executeAsync,
+                ex => true,
+                maxAttempts: 5,
+                sleepDuration: TimeSpan.Zero,
+                logger: _output);
+
+            Assert.Equal(4, attempts);
+            Assert.Equal(23, result);
+        }
+
+        [Fact]
+        public async Task DoesNotRetryIfShouldNotRetry()
+        {
+            var attempts = 0;
+            Func<Exception, bool> shouldRetry = ex => ex is InvalidOperationException;
+            Func<Task<int>> executeAsync = () => Task.Run<int>(async () =>
+            {
+                attempts++;
+                await Task.Yield();
+                throw new ApplicationException("Bad!");
+            });
+
+            var actualEx = await Assert.ThrowsAsync<ApplicationException>(() => RetryUtility.ExecuteWithRetry(
+                executeAsync,
+                ex => true,
+                maxAttempts: 5,
+                sleepDuration: TimeSpan.Zero,
+                logger: _output));
+
+            Assert.Equal(5, attempts);
+            Assert.Equal(actualEx.Message, "Bad!");
+        }
+    }
+}

--- a/test/NuGet.Services.EndToEnd.Test/Support/RetryingAzureManagementAPIWrapperTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/RetryingAzureManagementAPIWrapperTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.AzureManagement;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class RetryingAzureManagementAPIWrapperTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly string _subscription;
+        private readonly string _resourceGroup;
+        private readonly string _name;
+        private readonly string _slot;
+        private readonly CancellationToken _token;
+        private readonly string _properties;
+        private readonly Mock<IAzureManagementAPIWrapper> _inner;
+        private readonly RetryingAzureManagementAPIWrapper _target;
+
+        public RetryingAzureManagementAPIWrapperTests(ITestOutputHelper output)
+        {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+
+            _subscription = "test";
+            _resourceGroup = "rg";
+            _name = "name";
+            _slot = "staging";
+            _token = CancellationToken.None;
+            _properties = "{\"key\":\"value\"}";
+
+            _inner = new Mock<IAzureManagementAPIWrapper>();
+            _target = new RetryingAzureManagementAPIWrapper(
+                _inner.Object,
+                sleepDuration: TimeSpan.Zero);
+        }
+
+        [Fact]
+        public async Task PassesThroughParameters()
+        {
+            await _target.GetCloudServicePropertiesAsync(
+                _subscription,
+                _resourceGroup,
+                _name,
+                _slot,
+                _output,
+                _token);
+
+            _inner.Verify(
+                x => x.GetCloudServicePropertiesAsync(
+                    _subscription,
+                    _resourceGroup,
+                    _name,
+                    _slot,
+                    _token),
+                Times.Once);
+            _inner.Verify(
+                x => x.GetCloudServicePropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task RetriesWithWhenTransientExceptionTypeIsThrown()
+        {
+            _inner
+                .SetupSequence(x => x.GetCloudServicePropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new AzureManagementException("Some message."))
+                .ReturnsAsync(_properties);
+
+            var actual = await _target.GetCloudServicePropertiesAsync(
+                _subscription,
+                _resourceGroup,
+                _name,
+                _slot,
+                _output,
+                _token);
+            Assert.Equal(_properties, actual);
+            _inner.Verify(
+                x => x.GetCloudServicePropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task DoesNotRetryWhenOtherExceptionIsThrown()
+        {
+            var expected = new InvalidOperationException("Some message.");
+            _inner
+                .SetupSequence(x => x.GetCloudServicePropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(expected)
+                .ReturnsAsync(_properties);
+
+            var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetCloudServicePropertiesAsync(
+                _subscription,
+                _resourceGroup,
+                _name,
+                _slot,
+                _output,
+                _token));
+
+            Assert.Same(expected, actual);
+            _inner.Verify(
+                x => x.GetCloudServicePropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
I took a "data driven" approach to adding retries to E2E tests. I looked at all E2E test failures available in VSTS's history and analyzed the failure types. Transient errors fell into two categories:

1. Transient issues encountered while polling the search service, waiting for a package appear.
    - `SocketException`
    - `TaskCanceledException`
1. Azure Management API being down
    - `AzureManagementException`

To avoid retries potentially hiding bugs, I took this minimal approach and only added retries to these exception types and code paths.

We can easily extend the retries in the future as needed.