### PR TITLE
Either test the staging search slot OR all production slots (never both)

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGetExeTests.cs
+++ b/src/NuGet.Services.EndToEnd/NuGetExeTests.cs
@@ -345,11 +345,11 @@ namespace NuGet.Services.EndToEnd
                 },
             };
 
-            var sourceTypes = new[]
+            var sourceTypes = new List<SourceType> { SourceType.V3 };
+            if (!TestSettings.Create().SkipGalleryTests)
             {
-                SourceType.V2,
-                SourceType.V3,
-            };
+                sourceTypes.Add(SourceType.V2);
+            }
 
             var rows =
                 from pt in packageTypes

--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -30,6 +30,13 @@ namespace NuGet.Services.EndToEnd.Support
         private Uri _galleryUrl = null;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
+        public GalleryClient(SimpleHttpClient httpClient, TestSettings testSettings, IRetryingAzureManagementAPIWrapper azureManagementAPIWrapper)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _testSettings = testSettings ?? throw new ArgumentNullException(nameof(testSettings));
+            _azureManagementAPIWrapper = azureManagementAPIWrapper;
+        }
+
         public async Task<Uri> GetGalleryUrlAsync(ITestOutputHelper logger)
         {
             if (_galleryUrl != null)
@@ -81,13 +88,6 @@ namespace NuGet.Services.EndToEnd.Support
             }
 
             return _galleryUrl;
-        }
-
-        public GalleryClient(SimpleHttpClient httpClient, TestSettings testSettings, IRetryingAzureManagementAPIWrapper azureManagementAPIWrapper)
-        {
-            _httpClient = httpClient;
-            _testSettings = testSettings;
-            _azureManagementAPIWrapper = azureManagementAPIWrapper;
         }
 
         public async Task<IList<string>> AutocompletePackageIdsAsync(string id, bool includePrerelease, string semVerLevel, ITestOutputHelper logger)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -172,8 +172,7 @@ namespace NuGet.Services.EndToEnd.Support
                         searchServices.Add(await GetSearchServiceFromAzureAsync(mappedService, logger));
                     }
                 }
-
-                if (_testSettings.SearchServiceConfiguration.SingleSearchService != null)
+                else
                 {
                     logger.WriteLine($"Configured search service mode: use single search service.");
                     searchServices.Add(await GetSearchServiceFromAzureAsync(_testSettings.SearchServiceConfiguration.SingleSearchService, logger));

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -47,6 +47,11 @@ namespace NuGet.Services.EndToEnd.Support
 
         public string ApiKey { get; set; }
 
+        /// <summary>
+        /// Whether or not to skip end-to-end tests that hit gallery "read" endpoints, such as V2 or the autocomplete
+        /// endpoints. Note that this does not disable the usage of the push or unlist endpoints because these are
+        /// required for nearly all tests.
+        /// </summary>
         public bool SkipGalleryTests { get; set; }
 
         public static async Task<TestSettings> CreateAsync()
@@ -73,6 +78,11 @@ namespace NuGet.Services.EndToEnd.Support
             }
             
             return _testSettings;
+        }
+
+        public static TestSettings Create()
+        {
+            return CreateAsync().Result;
         }
 
         public static async Task<TestSettings> CreateLocalTestConfigurationAsync(string configurationName)

--- a/src/NuGet.Services.EndToEnd/Support/XUnitExtensions/GalleryTestTheoryAttribute.cs
+++ b/src/NuGet.Services.EndToEnd/Support/XUnitExtensions/GalleryTestTheoryAttribute.cs
@@ -9,8 +9,7 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public GalleryTestTheoryAttribute()
         {
-            var settings = TestSettings.CreateAsync().Result;
-            if (settings.SkipGalleryTests)
+            if (TestSettings.Create().SkipGalleryTests)
             {
                 Skip = "Not running Gallery tests!";
             }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1661.

I also need to remove the production slots from E2E configuration files. This will be a separate PR.

Also, make it so `SkipGalleryTests` covers all the things it should. V2 restore tests should be skipped.