### PR TITLE
Retry call to Azure Management API in case of HTTP request failure

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/RetryingAzureManagementAPIWrapper.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/RetryingAzureManagementAPIWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Services.AzureManagement;
@@ -35,7 +36,9 @@ namespace NuGet.Services.EndToEnd.Support
                     name,
                     slot,
                     token),
-                ex => ex is AzureManagementException,
+                ex => ex is AzureManagementException
+                   || ex.HasTypeOrInnerType<SocketException>()
+                   || ex.HasTypeOrInnerType<TaskCanceledException>(),
                 maxAttempts: RetryUtility.DefaultMaxAttempts,
                 sleepDuration: _sleepDuration,
                 logger: logger);


### PR DESCRIPTION
A `TaskCanceledException` was thrown when contacting Azure Management API.
https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=42467&_a=summary&view=logs

I added `SocketException` since both can be thrown by awaiting `HttpClient.SendAsync`.