### PR TITLE
Update end-to-end tests to use nuget 4.9.1

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -104,6 +104,7 @@
     <Content Include="Support\NuGetExe\nuget.4.7.0.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Support\NuGetExe\nuget.4.9.1.exe" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -104,7 +104,9 @@
     <Content Include="Support\NuGetExe\nuget.4.7.0.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Support\NuGetExe\nuget.4.9.1.exe" />
+    <Content Include="Support\NuGetExe\nuget.4.9.1.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/NuGet.Services.EndToEnd/NuGetExeTests.cs
+++ b/src/NuGet.Services.EndToEnd/NuGetExeTests.cs
@@ -124,6 +124,29 @@ namespace NuGet.Services.EndToEnd
                 hasRepositorySignature: _testSettings.IsRepositorySigningEnabled);
         }
 
+        [Theory]
+        [MemberData(nameof(PackageAndSourceTypes))]
+        public async Task Pre490NuGetExeCanVerifyRepositorySignedPackage(PackageType packageType, PackageType[] dependencies, bool semVer2, SourceType sourceType)
+        {
+            // Arrange - NuGet 4.9.0+ use a different version of the repository signing resource.
+            var nuGetExe = PrepareNuGetExe(sourceType, "4.7.0");
+            var package = await PreparePackageAsync(packageType, dependencies, semVer2);
+
+            // Act
+            var result = await nuGetExe.InstallAsync(
+                package.Id,
+                package.NormalizedVersion,
+                _outputDirectory,
+                _logger);
+
+            VerifyInstalled(package);
+            await VerifySignature(
+                nuGetExe,
+                package,
+                hasAuthorSignature: false,
+                hasRepositorySignature: _testSettings.IsRepositorySigningEnabled);
+        }
+
         [SignedPackageTestFact]
         public async Task LatestNuGetExeCanVerifyAuthorSignedPackage()
         {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/NuGetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/NuGetExeClient.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public class NuGetExeClient
     {
-        private const string LatestVersion = "4.7.0";
+        private const string LatestVersion = "4.9.1";
 
         private readonly TestSettings _testSettings;
         private readonly string _version;


### PR DESCRIPTION
This will be used to validate the 4.7/4.9 repository signing resources.

Example end-to-end test run on valid index: [#45908](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=45908)
Example end-to-end test run on invalid index (missing 4.9.0 signing resource): [#45987](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=45987)
Part of: https://github.com/NuGet/Engineering/issues/1778