### PR TITLE
Add Symbols end to end tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'c35bbc228717720bdbc610f3285259391635e90e'
+    [string]$BuildBranch = '91a7ba4c62498961fad14cd16f92aabccb474634'
 )
 
 # For TeamCity - If any issue occurs, this script fail the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail

--- a/build.ps1
+++ b/build.ps1
@@ -66,6 +66,9 @@ Invoke-BuildStep 'Getting private build tools' {
 Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet } `
     -ev +BuildErrors
 
+Invoke-BuildStep 'Installing DotNet.exe' { Install-DotnetCLI } `
+    -ev +BuildErrors
+
 Invoke-BuildStep 'Clearing package cache' { Clear-PackageCache } `
     -skip:(-not $CleanCache) `
     -ev +BuildErrors

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = '91a7ba4c62498961fad14cd16f92aabccb474634'
+    [string]$BuildBranch = '157a9e932837f8e261c0241670f15afd1c19f88a'
 )
 
 # For TeamCity - If any issue occurs, this script fail the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail

--- a/src/NuGet.Services.EndToEnd/Config/Dev.json
+++ b/src/NuGet.Services.EndToEnd/Config/Dev.json
@@ -3,6 +3,7 @@
     "V3IndexUrl": "https://apidev.nugettest.org/v3-index/index.json",
     "TrustedHttpsCertificates": [],
     "ApiKey": "API_KEY",
+    "SymbolServerDomain": "symbolsdev.nugettest.org",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://dev.nugettest.org"
     },

--- a/src/NuGet.Services.EndToEnd/Config/Dev.json
+++ b/src/NuGet.Services.EndToEnd/Config/Dev.json
@@ -3,7 +3,7 @@
     "V3IndexUrl": "https://apidev.nugettest.org/v3-index/index.json",
     "TrustedHttpsCertificates": [],
     "ApiKey": "API_KEY",
-    "SymbolServerDomain": "symbolsdev.nugettest.org",
+    "SymbolServerUrlTemplate": "https://symbolsdev.nugettest.org/download/symbols/{0}",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://dev.nugettest.org"
     },

--- a/src/NuGet.Services.EndToEnd/Config/Int.json
+++ b/src/NuGet.Services.EndToEnd/Config/Int.json
@@ -3,7 +3,7 @@
     "V3IndexUrl": "https://apiint.nugettest.org/v3-index/index.json",
     "TrustedHttpsCertificates": {},
     "ApiKey": "API_KEY",
-    "SymbolServerDomain": "symbolsint.nugettest.org",
+    "SymbolServerUrlTemplate": "https://symbolsint.nugettest.org/download/symbols/{0}",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://int.nugettest.org"
     },

--- a/src/NuGet.Services.EndToEnd/Config/Int.json
+++ b/src/NuGet.Services.EndToEnd/Config/Int.json
@@ -3,6 +3,7 @@
     "V3IndexUrl": "https://apiint.nugettest.org/v3-index/index.json",
     "TrustedHttpsCertificates": {},
     "ApiKey": "API_KEY",
+    "SymbolServerDomain": "symbolsint.nugettest.org",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://int.nugettest.org"
     },

--- a/src/NuGet.Services.EndToEnd/Config/Prod.json
+++ b/src/NuGet.Services.EndToEnd/Config/Prod.json
@@ -1,6 +1,6 @@
 ﻿{
   "TestSettings": {
-    "V3IndexUrl": "https://api.nugettest.org/v3/index.json",
+    "V3IndexUrl": "https://api.nuget.org/v3/index.json",
     "TrustedHttpsCertificates": {},
     "ApiKey": "API_KEY",
     "SymbolServerUrlTemplate": "https://symbols.nuget.org/download/symbols/{0}",

--- a/src/NuGet.Services.EndToEnd/Config/Prod.json
+++ b/src/NuGet.Services.EndToEnd/Config/Prod.json
@@ -3,7 +3,7 @@
     "V3IndexUrl": "https://api.nugettest.org/v3/index.json",
     "TrustedHttpsCertificates": {},
     "ApiKey": "API_KEY",
-    "SymbolServerDomain": "symbols.nuget.org",
+    "SymbolServerUrlTemplate": "https://symbols.nuget.org/download/symbols/{0}",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://www.nuget.org"
     },

--- a/src/NuGet.Services.EndToEnd/Config/Prod.json
+++ b/src/NuGet.Services.EndToEnd/Config/Prod.json
@@ -3,6 +3,7 @@
     "V3IndexUrl": "https://api.nugettest.org/v3/index.json",
     "TrustedHttpsCertificates": {},
     "ApiKey": "API_KEY",
+    "SymbolServerDomain": "symbols.nuget.org",
     "GalleryConfiguration": {
       "OverrideServiceUrl": "https://www.nuget.org"
     },

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -41,8 +41,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutocompleteResultTests.cs" />
+    <Compile Include="Support\PackageProperties.cs" />
+    <Compile Include="Support\Utilities\PortableMetadataReader.cs" />
+    <Compile Include="SymbolsPackageTests.cs" />
     <Compile Include="Support\Clients\ClientHelper.cs" />
     <Compile Include="Support\Clients\IRetryingAzureManagementAPIWrapper.cs" />
+    <Compile Include="Support\Clients\DotNetExeClient.cs" />
     <Compile Include="Support\Clients\RetryingAzureManagementAPIWrapper.cs" />
     <Compile Include="Support\Clients\SearchServiceProperties.cs" />
     <Compile Include="Support\Clients\V3IndexClient.cs" />
@@ -107,6 +111,15 @@
     <Content Include="Support\NuGetExe\nuget.4.9.1.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Support\TestData\E2E.TestPortableSymbols\E2E.TestPortableSymbols.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Support\TestData\E2E.TestPortableSymbols\TestMath.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Support\TestData\E2E.TestPortableSymbols\Properties\AssemblyInfo.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -124,6 +137,7 @@
     <ExternalConfig Include="ExternalConfig/*.*">
     </ExternalConfig>
   </ItemGroup>
+  <ItemGroup />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(ExternalConfig)" DestinationFolder="$(TargetDir)Config" />
   </Target>

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -100,9 +100,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
@@ -141,7 +139,6 @@
     <ExternalConfig Include="ExternalConfig/*.*">
     </ExternalConfig>
   </ItemGroup>
-  <ItemGroup />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(ExternalConfig)" DestinationFolder="$(TargetDir)Config" />
   </Target>

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Services.EndToEnd</RootNamespace>
     <AssemblyName>NuGet.Services.EndToEnd</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,7 +99,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutocompleteResultTests.cs" />
+    <Compile Include="Support\Clients\SymbolServerClient.cs" />
     <Compile Include="Support\PackageProperties.cs" />
     <Compile Include="Support\Utilities\PortableMetadataReader.cs" />
     <Compile Include="SymbolsPackageTests.cs" />

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Services.EndToEnd</RootNamespace>
     <AssemblyName>NuGet.Services.EndToEnd</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -100,7 +100,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -21,7 +21,8 @@ namespace NuGet.Services.EndToEnd.Support
             V2V3SearchClient v2v3Search,
             FlatContainerClient flatContainer,
             RegistrationClient registration,
-            NuGetExeClient nuGetExe)
+            NuGetExeClient nuGetExe,
+            SymbolServerClient symbolServerClient)
         {
             Gallery = gallery;
             V3Index = v3Index;
@@ -29,6 +30,7 @@ namespace NuGet.Services.EndToEnd.Support
             FlatContainer = flatContainer;
             Registration = registration;
             NuGetExe = nuGetExe;
+            SymbolServerClient = symbolServerClient;
         }
 
         public IGalleryClient Gallery { get; }
@@ -37,6 +39,7 @@ namespace NuGet.Services.EndToEnd.Support
         public FlatContainerClient FlatContainer { get; }
         public RegistrationClient Registration { get; }
         public NuGetExeClient NuGetExe { get; }
+        public SymbolServerClient SymbolServerClient { get; }
 
         public static Clients Initialize(TestSettings testSettings)
         {
@@ -79,6 +82,7 @@ namespace NuGet.Services.EndToEnd.Support
             var flatContainer = new FlatContainerClient(httpClient, v3Index);
             var registration = new RegistrationClient(httpClient, v3Index);
             var nuGetExe = new NuGetExeClient(testSettings, gallery);
+            var symbolServerClient = new SymbolServerClient(testSettings);
 
             return new Clients(
                 gallery,
@@ -86,7 +90,8 @@ namespace NuGet.Services.EndToEnd.Support
                 v2v3Search,
                 flatContainer,
                 registration,
-                nuGetExe);
+                nuGetExe,
+                symbolServerClient);
         }
 
         private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapper(TestSettings testSettings)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -21,7 +21,8 @@ namespace NuGet.Services.EndToEnd.Support
             V2V3SearchClient v2v3Search,
             FlatContainerClient flatContainer,
             RegistrationClient registration,
-            NuGetExeClient nuGetExe)
+            NuGetExeClient nuGetExe,
+            DotNetExeClient dotNetExe)
         {
             Gallery = gallery;
             V3Index = v3Index;
@@ -29,6 +30,7 @@ namespace NuGet.Services.EndToEnd.Support
             FlatContainer = flatContainer;
             Registration = registration;
             NuGetExe = nuGetExe;
+            DotNetExe = dotNetExe;
         }
 
         public IGalleryClient Gallery { get; }
@@ -37,6 +39,7 @@ namespace NuGet.Services.EndToEnd.Support
         public FlatContainerClient FlatContainer { get; }
         public RegistrationClient Registration { get; }
         public NuGetExeClient NuGetExe { get; }
+        public DotNetExeClient DotNetExe { get; }
 
         public static Clients Initialize(TestSettings testSettings)
         {
@@ -79,6 +82,7 @@ namespace NuGet.Services.EndToEnd.Support
             var flatContainer = new FlatContainerClient(httpClient, v3Index);
             var registration = new RegistrationClient(httpClient, v3Index);
             var nuGetExe = new NuGetExeClient(testSettings, gallery);
+            var dotNetExe = new DotNetExeClient(testSettings);
 
             return new Clients(
                 gallery,
@@ -86,7 +90,8 @@ namespace NuGet.Services.EndToEnd.Support
                 v2v3Search,
                 flatContainer,
                 registration,
-                nuGetExe);
+                nuGetExe,
+                dotNetExe);
         }
 
         private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapper(TestSettings testSettings)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -82,7 +82,7 @@ namespace NuGet.Services.EndToEnd.Support
             var flatContainer = new FlatContainerClient(httpClient, v3Index);
             var registration = new RegistrationClient(httpClient, v3Index);
             var nuGetExe = new NuGetExeClient(testSettings, gallery);
-            var dotNetExe = new DotNetExeClient(testSettings);
+            var dotNetExe = new DotNetExeClient();
 
             return new Clients(
                 gallery,

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -21,8 +21,7 @@ namespace NuGet.Services.EndToEnd.Support
             V2V3SearchClient v2v3Search,
             FlatContainerClient flatContainer,
             RegistrationClient registration,
-            NuGetExeClient nuGetExe,
-            DotNetExeClient dotNetExe)
+            NuGetExeClient nuGetExe)
         {
             Gallery = gallery;
             V3Index = v3Index;
@@ -30,7 +29,6 @@ namespace NuGet.Services.EndToEnd.Support
             FlatContainer = flatContainer;
             Registration = registration;
             NuGetExe = nuGetExe;
-            DotNetExe = dotNetExe;
         }
 
         public IGalleryClient Gallery { get; }
@@ -39,7 +37,6 @@ namespace NuGet.Services.EndToEnd.Support
         public FlatContainerClient FlatContainer { get; }
         public RegistrationClient Registration { get; }
         public NuGetExeClient NuGetExe { get; }
-        public DotNetExeClient DotNetExe { get; }
 
         public static Clients Initialize(TestSettings testSettings)
         {
@@ -82,7 +79,6 @@ namespace NuGet.Services.EndToEnd.Support
             var flatContainer = new FlatContainerClient(httpClient, v3Index);
             var registration = new RegistrationClient(httpClient, v3Index);
             var nuGetExe = new NuGetExeClient(testSettings, gallery);
-            var dotNetExe = new DotNetExeClient();
 
             return new Clients(
                 gallery,
@@ -90,8 +86,7 @@ namespace NuGet.Services.EndToEnd.Support
                 v2v3Search,
                 flatContainer,
                 registration,
-                nuGetExe,
-                dotNetExe);
+                nuGetExe);
         }
 
         private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapper(TestSettings testSettings)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -48,11 +48,19 @@ namespace NuGet.Services.EndToEnd.Support
 
             var joinedArguments = string.Join(" ", arguments);
 
+            // New installation of DOTNET invokes first time user experience which involves caching, decompressing packages etc.
+            // This prevents faster package build times, disable this behavior using environment variable
+            var environmentVariables = new Dictionary<string, string>
+            {
+                { "DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1" }
+            };
+
             return await CommandRunner.RunAsync(
                 filePath,
                 workingDirectory,
                 joinedArguments,
-                logger);
+                logger,
+                environmentVariables);
         }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -8,12 +8,9 @@ using Xunit.Abstractions;
 
 namespace NuGet.Services.EndToEnd.Support
 {
-    public class DotNetExeClient
+    public static class DotNetExeClient
     {
-        public DotNetExeClient()
-        { }
-
-        public async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
+        public static async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
         {
             var arguments = new List<string>
             {
@@ -26,7 +23,7 @@ namespace NuGet.Services.EndToEnd.Support
             return await RunAsync(projectDirectory, arguments, logger);
         }
 
-        private async Task<CommandRunnerResult> RunAsync(string workingDirectory, List<string> arguments, ITestOutputHelper logger)
+        private static async Task<CommandRunnerResult> RunAsync(string workingDirectory, List<string> arguments, ITestOutputHelper logger)
         {
             var fileName = $"dotnet.exe";
             var filePath = Path.Combine(EnvironmentSettings.DotnetCliDirectory, fileName);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class DotNetExeClient
+    {
+        private readonly TestSettings _testSettings;
+
+        public DotNetExeClient(TestSettings testSettings)
+        {
+            _testSettings = testSettings;
+        }
+
+        public async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
+        {
+            var arguments = new List<string>
+            {
+                "build",
+                projectPath
+            };
+
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+
+            return await RunAsync(projectDirectory, arguments, logger);
+        }
+
+        private async Task<CommandRunnerResult> RunAsync(string workingDirectory, List<string> arguments, ITestOutputHelper logger)
+        {
+            var fileName = $"dotnet.exe";
+            var filePath = Path.Combine(EnvironmentSettings.DotnetCliDirectory, fileName);
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"The ${filePath} not found. Make sure the ${fileName} is installed correctly.");
+            }
+
+            var joinedArguments = string.Join(" ", arguments);
+
+            return await CommandRunner.RunAsync(
+                filePath,
+                workingDirectory,
+                joinedArguments,
+                logger);
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -13,7 +13,7 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public static readonly string ExeName = "dotnet.exe";
 
-        public static async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
+        public static async Task<CommandRunnerResult> BuildProjectAsync(string projectPath, ITestOutputHelper logger)
         {
             var arguments = new List<string>
             {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -43,7 +43,7 @@ namespace NuGet.Services.EndToEnd.Support
             string filePath;
             if (!TryGetDotNetExe(out filePath))
             {
-                throw new FileNotFoundException($"The ${filePath} not found. Make sure the ${ExeName} is installed correctly.");
+                throw new FileNotFoundException($"The {filePath} not found. Make sure the {ExeName} is installed correctly.");
             }
 
             var joinedArguments = string.Join(" ", arguments);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -10,12 +10,8 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public class DotNetExeClient
     {
-        private readonly TestSettings _testSettings;
-
-        public DotNetExeClient(TestSettings testSettings)
-        {
-            _testSettings = testSettings;
-        }
+        public DotNetExeClient()
+        { }
 
         public async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
         {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public static class DotNetExeClient
     {
+        public static readonly string ExeName = "dotnet.exe";
+
         public static async Task<CommandRunnerResult> BuildProject(string projectPath, ITestOutputHelper logger)
         {
             var arguments = new List<string>
@@ -23,14 +26,24 @@ namespace NuGet.Services.EndToEnd.Support
             return await RunAsync(projectDirectory, arguments, logger);
         }
 
+        public static bool TryGetDotNetExe(out string filePath)
+        {
+            filePath = null;
+            if (string.IsNullOrEmpty(EnvironmentSettings.DotnetInstallDirectory))
+            {
+                return false; 
+            }
+
+            filePath = Path.Combine(EnvironmentSettings.DotnetInstallDirectory, ExeName);
+            return File.Exists(filePath);
+        }
+
         private static async Task<CommandRunnerResult> RunAsync(string workingDirectory, List<string> arguments, ITestOutputHelper logger)
         {
-            var fileName = $"dotnet.exe";
-            var filePath = Path.Combine(EnvironmentSettings.DotnetCliDirectory, fileName);
-
-            if (!File.Exists(filePath))
+            string filePath;
+            if (!TryGetDotNetExe(out filePath))
             {
-                throw new FileNotFoundException($"The ${filePath} not found. Make sure the ${fileName} is installed correctly.");
+                throw new FileNotFoundException($"The ${filePath} not found. Make sure the ${ExeName} is installed correctly.");
             }
 
             var joinedArguments = string.Join(" ", arguments);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -108,10 +108,13 @@ namespace NuGet.Services.EndToEnd.Support
             return await _httpClient.GetJsonAsync<List<string>>(uri, logger);
         }
 
-        public async Task PushAsync(Stream nupkgStream, ITestOutputHelper logger)
+        public async Task PushAsync(Stream nupkgStream, ITestOutputHelper logger, bool isSymbolsPackage = false)
         {
             var galleryEndpoint = await GetGalleryUrlAsync(logger);
-            var url = $"{galleryEndpoint}/api/v2/package";
+            var url = isSymbolsPackage
+                ? $"{galleryEndpoint}/api/v2/symbolpackage"
+                : $"{galleryEndpoint}/api/v2/package";
+
             using (var httpClient = new HttpClient())
             using (var request = new HttpRequestMessage(HttpMethod.Put, url))
             {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.EndToEnd.Support
     public interface IGalleryClient
     {
         Task<Uri> GetGalleryUrlAsync(ITestOutputHelper logger);
-        Task PushAsync(Stream nupkgStream, ITestOutputHelper logger);
+        Task PushAsync(Stream nupkgStream, ITestOutputHelper logger, bool isSymbolsPackage);
         Task UnlistAsync(string id, string version, ITestOutputHelper logger);
         Task RelistAsync(string id, string version, ITestOutputHelper logger);
         Task<IList<string>> AutocompletePackageIdsAsync(string id, bool includePrerelease, string semVerLevel, ITestOutputHelper logger);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.EndToEnd.Support
     public interface IGalleryClient
     {
         Task<Uri> GetGalleryUrlAsync(ITestOutputHelper logger);
-        Task PushAsync(Stream nupkgStream, ITestOutputHelper logger, bool isSymbolsPackage);
+        Task PushAsync(Stream nupkgStream, ITestOutputHelper logger, bool isSymbolsPackage = false);
         Task UnlistAsync(string id, string version, ITestOutputHelper logger);
         Task RelistAsync(string id, string version, ITestOutputHelper logger);
         Task<IList<string>> AutocompletePackageIdsAsync(string id, bool includePrerelease, string semVerLevel, ITestOutputHelper logger);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -74,7 +74,9 @@ namespace NuGet.Services.EndToEnd.Support
             {
                 using (var httpClient = new HttpClient())
                 {
-                    // Add Checksum headers for fetching the pdbs from symbol server.
+                    // Add Checksum headers for fetching the pdbs from symbol server. This header is used
+                    // by the symbol server to validate the request(provided by supported clients) for 
+                    // portable PDBs.
                     httpClient.DefaultRequestHeaders.Add(SymbolServerHeaderKey, SymbolServerHeaderValue);
                     using (var response = await httpClient.GetAsync(symbolFileEndpoint))
                     {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -43,8 +43,6 @@ namespace NuGet.Services.EndToEnd.Support
             string failureMessageFormat,
             ITestOutputHelper logger)
         {
-            // We perform the retry at this level so that we can re-fetch the list of search service instances from
-            // Azure Management API. This list can change during scale-up or scale-down events.
             return RetryUtility.ExecuteWithRetry(
                 async () =>
                 {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -17,7 +17,6 @@ namespace NuGet.Services.EndToEnd.Support
     public class SymbolServerClient
     {
         private readonly TestSettings _testSettings;
-        private readonly string _symbolServerEndpointTemplate = "https://{0}/download/symbols/{1}";
         private static readonly string SymbolServerHeaderKey = "SymbolChecksum";
         private static readonly string SymbolServerHeaderValue = "1";
 
@@ -70,11 +69,7 @@ namespace NuGet.Services.EndToEnd.Support
             await Task.Yield();
 
             var complete = false;
-            var symbolFileEndpoint = new Uri(
-                string.Format(
-                    _symbolServerEndpointTemplate,
-                    _testSettings.SymbolServerDomain,
-                    indexedFileName));
+            var symbolFileEndpoint = new Uri(string.Format(_testSettings.SymbolServerUrlTemplate, indexedFileName));
 
             var duration = Stopwatch.StartNew();
             while (!complete && duration.Elapsed < TestData.SymbolsWaitDuration)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class SymbolServerClient
+    {
+        private readonly TestSettings _testSettings;
+        private readonly string _symbolServerEndpointTemplate = "https://{0}/download/symbols/{1}";
+        private static readonly string SymbolServerHeaderKey = "SymbolChecksum";
+        private static readonly string SymbolServerHeaderValue = "1";
+
+        public SymbolServerClient(TestSettings testSettings)
+        {
+            _testSettings = testSettings;
+        }
+
+        public async Task VerifySymbolFilesAvailable(string id, string version, HashSet<string> indexedFiles, ITestOutputHelper logger)
+        {
+            await Task.Yield();
+
+            await PollAsync(indexedFiles,
+                $"Waiting for symbols package for {id} {version} to be available on symbol server",
+                $"Symbols package {id} {version} is available on {{0}} after waiting {{1}}",
+                $"Symbols package {id} {version} was still not available on {{0}} after waiting {{1}}",
+                logger);
+        }
+
+        private Task PollAsync(
+            HashSet<string> indexedFiles,
+            string startingMessage,
+            string successMessageFormat,
+            string failureMessageFormat,
+            ITestOutputHelper logger)
+        {
+            // We perform the retry at this level so that we can re-fetch the list of search service instances from
+            // Azure Management API. This list can change during scale-up or scale-down events.
+            return RetryUtility.ExecuteWithRetry(
+                async () =>
+                {
+                    logger.WriteLine(startingMessage);
+                    var tasks = indexedFiles
+                        .Select(file => PollAsync(file, successMessageFormat, failureMessageFormat, logger))
+                        .ToList();
+
+                    await Task.WhenAll(tasks);
+                },
+                ex => ex.HasTypeOrInnerType<SocketException>()
+                    || ex.HasTypeOrInnerType<TaskCanceledException>(),
+                logger: logger);
+        }
+
+        private async Task PollAsync(
+            string indexedFileName,
+            string successMessageFormat,
+            string failureMessageFormat,
+            ITestOutputHelper logger)
+        {
+            await Task.Yield();
+
+            var complete = false;
+            var symbolFileEndpoint = new Uri(
+                string.Format(
+                    _symbolServerEndpointTemplate,
+                    _testSettings.SymbolServerDomain,
+                    indexedFileName));
+
+            var duration = Stopwatch.StartNew();
+            while (!complete && duration.Elapsed < TestData.SymbolsWaitDuration)
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    // Add Checksum headers for fetching the pdbs from symbol server.
+                    httpClient.DefaultRequestHeaders.Add(SymbolServerHeaderKey, SymbolServerHeaderValue);
+                    using (var response = await httpClient.GetAsync(symbolFileEndpoint))
+                    {
+                        complete = response.StatusCode == HttpStatusCode.OK;
+
+                        if (!complete && duration.Elapsed + TestData.SymbolsSleepDuration < TestData.SymbolsWaitDuration)
+                        {
+                            await Task.Delay(TestData.SymbolsSleepDuration);
+                        }
+                    }
+                }
+            }
+
+            Assert.True(complete, string.Format(failureMessageFormat, symbolFileEndpoint, duration.Elapsed));
+            logger.WriteLine(string.Format(successMessageFormat, symbolFileEndpoint, duration.Elapsed));
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -80,11 +80,12 @@ namespace NuGet.Services.EndToEnd.Support
                     {
                         complete = response.StatusCode == HttpStatusCode.OK;
 
-                        if (!complete && duration.Elapsed + TestData.SymbolsSleepDuration < TestData.SymbolsWaitDuration)
-                        {
-                            await Task.Delay(TestData.SymbolsSleepDuration);
-                        }
                     }
+                }
+
+                if (!complete && duration.Elapsed + TestData.SymbolsSleepDuration < TestData.SymbolsWaitDuration)
+                {
+                    await Task.Delay(TestData.SymbolsSleepDuration);
                 }
             }
 

--- a/src/NuGet.Services.EndToEnd/Support/EnvironmentSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/EnvironmentSettings.cs
@@ -34,7 +34,7 @@ namespace NuGet.Services.EndToEnd.Support
         /// <summary>
         /// The path to the signed package that should be used for tests.
         /// </summary>
-        public static string DotnetCliDirectory = GetEnvironmentVariable("DOTNET_INSTALL_DIR", required: false);
+        public static string DotnetInstallDirectory = GetEnvironmentVariable("DOTNET_INSTALL_DIR", required: false);
 
         private static string GetEnvironmentVariable(string key, bool required)
         {

--- a/src/NuGet.Services.EndToEnd/Support/EnvironmentSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/EnvironmentSettings.cs
@@ -31,6 +31,11 @@ namespace NuGet.Services.EndToEnd.Support
         /// </summary>
         public static string SignedPackagePath = GetEnvironmentVariable("SignedPackagePath", required: false);
 
+        /// <summary>
+        /// The path to the signed package that should be used for tests.
+        /// </summary>
+        public static string DotnetCliDirectory = GetEnvironmentVariable("DOTNET_INSTALL_DIR", required: false);
+
         private static string GetEnvironmentVariable(string key, bool required)
         {
             var output = Targets

--- a/src/NuGet.Services.EndToEnd/Support/Package.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Package.cs
@@ -17,7 +17,7 @@ namespace NuGet.Services.EndToEnd.Support
             string normalizedVersion,
             string fullVersion,
             ReadOnlyCollection<byte> nupkgBytes) 
-            : this (id, normalizedVersion, fullVersion, nupkgBytes, PackageProperties.Default()) { }
+            : this (id, normalizedVersion, fullVersion, nupkgBytes, new PackageProperties()) { }
 
         private Package(
             string id,
@@ -74,7 +74,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         public static Package Create(PackageCreationContext context, IEnumerable<string> files)
         {
-            return Create(context, files, PackageProperties.Default());
+            return Create(context, files, new PackageProperties());
         }
 
         public static Package Create(PackageCreationContext context, IEnumerable<string> files, PackageProperties properties)
@@ -141,8 +141,7 @@ namespace NuGet.Services.EndToEnd.Support
             var memoryStream = new MemoryStream();
             using (FileStream fileStream = File.OpenRead(filename))
             {
-                memoryStream.SetLength(fileStream.Length);
-                fileStream.Read(memoryStream.GetBuffer(), 0, (int)fileStream.Length);
+                fileStream.CopyTo(memoryStream);
             }
 
             memoryStream.Position = 0;

--- a/src/NuGet.Services.EndToEnd/Support/Package.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Package.cs
@@ -80,8 +80,10 @@ namespace NuGet.Services.EndToEnd.Support
         public static Package Create(PackageCreationContext context, IEnumerable<string> files, PackageProperties properties)
         {
             var physicalPackageFilesList = files
-                .Select(x => GetMemoryStreamForFile(x))
-                .Select(x => new PhysicalPackageFile(x));
+                .Select(x => new { FileName = Path.GetFileName(x), Stream = GetMemoryStreamForFile(x) })
+                .Select(x => new PhysicalPackageFile(x.Stream) {
+                    TargetPath = x.FileName
+                });
 
             ReadOnlyCollection<byte> nupkgBytes;
             using (var nupkgStream = TestData.BuildPackageStreamForFiles(context, physicalPackageFilesList, properties.IsSymbolsPackage))

--- a/src/NuGet.Services.EndToEnd/Support/Package.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Package.cs
@@ -138,7 +138,6 @@ namespace NuGet.Services.EndToEnd.Support
 
         private static MemoryStream GetMemoryStreamForFile(string filename)
         {
-
             var memoryStream = new MemoryStream();
             using (FileStream fileStream = File.OpenRead(filename))
             {

--- a/src/NuGet.Services.EndToEnd/Support/Package.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Package.cs
@@ -63,8 +63,8 @@ namespace NuGet.Services.EndToEnd.Support
         {
             ReadOnlyCollection<byte> nupkgBytes;
             using (var nupkgStream = TestData.BuildPackageStream(context))
+            using (var bufferStream = new MemoryStream())
             {
-                var bufferStream = new MemoryStream();
                 nupkgStream.CopyTo(bufferStream);
                 nupkgBytes = Array.AsReadOnly(bufferStream.ToArray());
             }
@@ -87,8 +87,8 @@ namespace NuGet.Services.EndToEnd.Support
 
             ReadOnlyCollection<byte> nupkgBytes;
             using (var nupkgStream = TestData.BuildPackageStreamForFiles(context, physicalPackageFilesList, properties.IsSymbolsPackage))
+            using(var bufferStream = new MemoryStream())
             {
-                var bufferStream = new MemoryStream();
                 nupkgStream.CopyTo(bufferStream);
                 nupkgBytes = Array.AsReadOnly(bufferStream.ToArray());
             }

--- a/src/NuGet.Services.EndToEnd/Support/Package.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Package.cs
@@ -17,7 +17,7 @@ namespace NuGet.Services.EndToEnd.Support
             string normalizedVersion,
             string fullVersion,
             ReadOnlyCollection<byte> nupkgBytes) 
-            : this (id, normalizedVersion, fullVersion, nupkgBytes, new PackageProperties()) { }
+            : this (id, normalizedVersion, fullVersion, nupkgBytes, PackageProperties.Default()) { }
 
         private Package(
             string id,
@@ -82,7 +82,7 @@ namespace NuGet.Services.EndToEnd.Support
             var physicalPackageFilesList = files
                 .Select(x => new { FileName = Path.GetFileName(x), Stream = GetMemoryStreamForFile(x) })
                 .Select(x => new PhysicalPackageFile(x.Stream) {
-                    TargetPath = x.FileName
+                    TargetPath = $"lib/{x.FileName}"
                 });
 
             ReadOnlyCollection<byte> nupkgBytes;

--- a/src/NuGet.Services.EndToEnd/Support/PackageCreationContext.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageCreationContext.cs
@@ -12,6 +12,5 @@ namespace NuGet.Services.EndToEnd.Support
         public string NormalizedVersion { get; set; }
         public string FullVersion { get; set; }
         public IEnumerable<PackageDependencyGroup> DependencyGroups { get; set; }
-        public bool IsSymbolsPackage { get; set; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/PackageCreationContext.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageCreationContext.cs
@@ -12,5 +12,6 @@ namespace NuGet.Services.EndToEnd.Support
         public string NormalizedVersion { get; set; }
         public string FullVersion { get; set; }
         public IEnumerable<PackageDependencyGroup> DependencyGroups { get; set; }
+        public bool IsSymbolsPackage { get; set; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public class PackageProperties
+    {
+        public bool IsSymbolsPackage { get; }
+
+        public HashSet<string> IndexedFiles { get; }
+
+        public PackageProperties() { }
+
+        public PackageProperties(bool isSymbolsPackage, HashSet<string> indexedFiles)
+        {
+            IsSymbolsPackage = IsSymbolsPackage;
+            IndexedFiles = indexedFiles;
+        }
+
+        public static PackageProperties Default()
+        {
+            return new PackageProperties();
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
@@ -11,7 +11,10 @@ namespace NuGet.Services.EndToEnd.Support
 
         public HashSet<string> IndexedFiles { get; }
 
-        public PackageProperties() { }
+        public PackageProperties()
+        {
+            IndexedFiles = new HashSet<string>();
+        }
 
         public PackageProperties(bool isSymbolsPackage, HashSet<string> indexedFiles)
         {

--- a/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageProperties.cs
@@ -15,7 +15,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         public PackageProperties(bool isSymbolsPackage, HashSet<string> indexedFiles)
         {
-            IsSymbolsPackage = IsSymbolsPackage;
+            IsSymbolsPackage = isSymbolsPackage;
             IndexedFiles = indexedFiles;
         }
 

--- a/src/NuGet.Services.EndToEnd/Support/PackageType.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageType.cs
@@ -19,6 +19,6 @@ namespace NuGet.Services.EndToEnd.Support
         SemVer2StableMetadataUnlisted,
         FullValidation,
         Signed,
-        SymbolsPackage
+        SymbolsPackage,
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/PackageType.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageType.cs
@@ -19,5 +19,6 @@ namespace NuGet.Services.EndToEnd.Support
         SemVer2StableMetadataUnlisted,
         FullValidation,
         Signed,
+        SymbolsPackage
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -323,7 +323,7 @@ namespace NuGet.Services.EndToEnd.Support
                 var buildCommandResult = await DotNetExeClient.BuildProject(projectPath, logger);
                 if (!string.IsNullOrEmpty(buildCommandResult.Error))
                 {
-                    throw new Exception($"Error building symbols package! {buildCommandResult.Error}");
+                    throw new Exception($"Error building symbols package! Error: {buildCommandResult.Error} Output: {buildCommandResult.Output}");
                 }
 
                 // Build nupkg and snupkg from appropriate files

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -255,7 +255,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         /// <summary>
         /// Return the list of <see cref="PackageToPrepare"/> in the ordered form
-        /// for which we want to run all the tasks synchronously
+        /// for which we want to run all the tasks sequentially
         /// </summary>
         /// <returns>Ordered list of tasks to run for <see cref="PackageToPrepare"/></returns>
         private async Task<List<PackageToPrepare>> InitializePackagesAsync(PackageType packageType, ITestOutputHelper logger)

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -39,7 +39,7 @@ namespace NuGet.Services.EndToEnd.Support
         private readonly object _packageIdsLock = new object();
         private readonly IDictionary<PackageType, string> _packageIds = new Dictionary<PackageType, string>();
         private IGalleryClient _galleryClient;
-        private DotNetExeClient _dotnetExeClient;
+
         private static readonly string SymbolsProjectTemplateFolder = Path.Combine(Environment.CurrentDirectory, "Support", "TestData", "E2E.TestPortableSymbols");
 
         public PushedPackagesFixture()
@@ -58,11 +58,6 @@ namespace NuGet.Services.EndToEnd.Support
             if (_galleryClient == null)
             {
                 _galleryClient = Clients.Gallery;
-            }
-
-            if (_dotnetExeClient == null)
-            {
-                _dotnetExeClient = Clients.DotNetExe;
             }
         }
 
@@ -325,7 +320,7 @@ namespace NuGet.Services.EndToEnd.Support
                 var projectPath = CopySymbolsProjectFromTemplate(id, version, testDirectory.FullPath);
 
                 // Build the symbols project with the DotNet.exe
-                var buildCommandResult = await _dotnetExeClient.BuildProject(projectPath, logger);
+                var buildCommandResult = await DotNetExeClient.BuildProject(projectPath, logger);
                 if (!string.IsNullOrEmpty(buildCommandResult.Error))
                 {
                     throw new Exception($"Error building symbols package! {buildCommandResult.Error}");

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -125,7 +125,10 @@ namespace NuGet.Services.EndToEnd.Support
                 await Task.WhenAll(pushTasks.Values);
 
                 // Use the packages that we just pushed.
-                return _packages[requestedPackageType];
+                lock (_packagesLock)
+                {
+                    return _packages[requestedPackageType];
+                }
             }
             finally
             {

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -19,29 +20,61 @@ namespace NuGet.Services.EndToEnd.Support
 
         public static Stream BuildPackageStream(PackageCreationContext context)
         {
+            var files = new List<PhysicalPackageFile>() {
+                new PhysicalPackageFile(new MemoryStream())
+                {
+                    TargetPath = "tools/empty.txt"
+                },
+                new PhysicalPackageFile(new MemoryStream())
+                {
+                    TargetPath = $"lib/{TargetFramework.GetShortFolderName()}/_._"
+                }
+            };
+
+            return BuildPackageStreamForFiles(context, files, isSymbolsPackage: false);
+        }
+
+        public static Stream BuildPackageStreamForFiles(PackageCreationContext context, IEnumerable<PhysicalPackageFile> files, bool isSymbolsPackage)
+        {
+            var packageBuilder = GetPackageBuilder(context, files);
+
+            if (!isSymbolsPackage)
+            {
+                packageBuilder.Authors.Add("EndToEndTests");
+            }
+            else
+            {
+                packageBuilder.PackageTypes.Add(new Packaging.Core.PackageType("SymbolsPackage", Packaging.Core.PackageType.EmptyVersion));
+            }
+
+            return GetStreamFromBuilder(packageBuilder);
+        }
+
+        private static PackageBuilder GetPackageBuilder(PackageCreationContext context, IEnumerable<PhysicalPackageFile> files)
+        {
             var packageBuilder = new PackageBuilder();
             packageBuilder.Id = context.Id;
             packageBuilder.Version = NuGetVersion.Parse(context.FullVersion ?? context.NormalizedVersion);
-            packageBuilder.Authors.Add("EndToEndTests");
             packageBuilder.Description = $"Description of {context.Id}";
-            packageBuilder.Files.Add(new PhysicalPackageFile(new MemoryStream())
+            foreach (PhysicalPackageFile file in files)
             {
-                TargetPath = "tools/empty.txt"
-            });
-            packageBuilder.Files.Add(new PhysicalPackageFile(new MemoryStream())
-            {
-                TargetPath = $"lib/{TargetFramework.GetShortFolderName()}/_._"
-            });
+                packageBuilder.Files.Add(file);
+            }
 
             if (context.DependencyGroups != null)
             {
                 packageBuilder.DependencyGroups.AddRange(context.DependencyGroups);
             }
 
+            return packageBuilder;
+        }
+
+        private static Stream GetStreamFromBuilder(PackageBuilder packageBuilder)
+        {
             var memoryStream = new MemoryStream();
             packageBuilder.Save(memoryStream);
             memoryStream.Position = 0;
-            
+
             return memoryStream;
         }
     }

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -17,6 +17,8 @@ namespace NuGet.Services.EndToEnd.Support
         public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan SearchWaitDuration = TimeSpan.FromMinutes(35);
         public static readonly TimeSpan V3SleepDuration = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan SymbolsWaitDuration = TimeSpan.FromMinutes(20);
+        public static readonly TimeSpan SymbolsSleepDuration = TimeSpan.FromSeconds(5);
 
         public static Stream BuildPackageStream(PackageCreationContext context)
         {

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -22,16 +22,17 @@ namespace NuGet.Services.EndToEnd.Support
 
         public static Stream BuildPackageStream(PackageCreationContext context)
         {
-            var files = new List<PhysicalPackageFile>() {
-                new PhysicalPackageFile(new MemoryStream())
+            var files = new List<PhysicalPackageFile>()
                 {
-                    TargetPath = "tools/empty.txt"
-                },
-                new PhysicalPackageFile(new MemoryStream())
-                {
-                    TargetPath = $"lib/{TargetFramework.GetShortFolderName()}/_._"
-                }
-            };
+                    new PhysicalPackageFile(new MemoryStream())
+                    {
+                        TargetPath = "tools/empty.txt"
+                    },
+                    new PhysicalPackageFile(new MemoryStream())
+                    {
+                        TargetPath = $"lib/{TargetFramework.GetShortFolderName()}/_._"
+                    }
+                };
 
             return BuildPackageStreamForFiles(context, files, isSymbolsPackage: false);
         }

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C33480B0-B971-430B-A30F-F13A9CABB707}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>E2E.TestPortableSymbols</RootNamespace>
+    <AssemblyName>E2E.TestPortableSymbols</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestMath.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("{0}")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("HP Inc.")]
+[assembly: AssemblyProduct("E2E.TestPortableSymbols")]
+[assembly: AssemblyCopyright("Copyright © HP Inc. 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c33480b0-b971-430b-a30f-f13a9cabb707")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("{1}")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("{0}")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("HP Inc.")]
+[assembly: AssemblyCompany(".NET Foundation.")]
 [assembly: AssemblyProduct("E2E.TestPortableSymbols")]
-[assembly: AssemblyCopyright("Copyright © HP Inc. 2018")]
+[assembly: AssemblyCopyright("Copyright (c) .NET Foundation")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/Properties/AssemblyInfo.cs
@@ -6,31 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("{0}")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany(".NET Foundation.")]
 [assembly: AssemblyProduct("E2E.TestPortableSymbols")]
 [assembly: AssemblyCopyright("Copyright (c) .NET Foundation")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c33480b0-b971-430b-a30f-f13a9cabb707")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("{1}")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/TestMath.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/TestMath.cs
@@ -1,0 +1,11 @@
+﻿namespace E2E.TestPortableSymbols
+{
+    public class TestMath
+    {
+        public static long Add(int a, int b)
+        {
+            // Test stream {0}
+            return a + b;
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -47,6 +47,8 @@ namespace NuGet.Services.EndToEnd.Support
 
         public string ApiKey { get; set; }
 
+        public string SymbolServerDomain { get; set; }
+
         /// <summary>
         /// Whether or not to skip end-to-end tests that hit gallery "read" endpoints, such as V2 or the autocomplete
         /// endpoints. Note that this does not disable the usage of the push or unlist endpoints because these are

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -47,7 +47,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         public string ApiKey { get; set; }
 
-        public string SymbolServerDomain { get; set; }
+        public string SymbolServerUrlTemplate { get; set; }
 
         /// <summary>
         /// Whether or not to skip end-to-end tests that hit gallery "read" endpoints, such as V2 or the autocomplete

--- a/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
@@ -9,6 +9,12 @@ namespace NuGet.Services.EndToEnd.Support.Utilities
 {
     public static class PortableMetadataReader
     {
+        /// <summary>
+        /// This gets format for the VSTS symbol server indexed files. This format is 
+        /// based off of the PDB name and the signature present in the PDB 
+        /// </summary>
+        /// <param name="pdbFullPath">Path to the PDB file</param>
+        /// <returns>The indexed format of PDB file for the VSTS symbol server</returns>
         public static string GetIndex(string pdbFullPath)
         {
             if (pdbFullPath == null)

--- a/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
@@ -11,12 +11,12 @@ namespace NuGet.Services.EndToEnd.Support.Utilities
     {
         public static string GetIndex(string pdbFullPath)
         {
-            var indexingPath = string.Empty;
             if (pdbFullPath == null)
             {
                 throw new ArgumentNullException(nameof(pdbFullPath));
             }
 
+            var indexingPath = string.Empty;
             using (var stream = File.OpenRead(pdbFullPath))
             using (var pdbReaderProvider = MetadataReaderProvider.FromPortablePdbStream(stream, MetadataStreamOptions.LeaveOpen))
             {

--- a/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+
+namespace NuGet.Services.EndToEnd.Support.Utilities
+{
+    public static class PortableMetadataReader
+    {
+        public static string GetIndex(string pdbFullPath)
+        {
+            var indexingPath = string.Empty;
+            if (pdbFullPath == null)
+            {
+                throw new ArgumentNullException(nameof(pdbFullPath));
+            }
+
+            using (var stream = File.OpenRead(pdbFullPath))
+            using (var pdbReaderProvider = MetadataReaderProvider.FromPortablePdbStream(stream, MetadataStreamOptions.LeaveOpen))
+            {
+                var pdbReader = pdbReaderProvider.GetMetadataReader();
+                var pdbSignature = new BlobContentId(pdbReader.DebugMetadataHeader.Id).Guid;
+                var pdbFileName = Path.GetFileName(pdbFullPath).ToLowerInvariant();
+                var pdbAge = "FFFFFFFF";
+                indexingPath = $"{pdbFileName}\\{pdbSignature.ToString("N")}{pdbAge}\\{pdbFileName}";
+            }
+
+            return indexingPath;
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Utilities/PortableMetadataReader.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.EndToEnd.Support.Utilities
                 var pdbSignature = new BlobContentId(pdbReader.DebugMetadataHeader.Id).Guid;
                 var pdbFileName = Path.GetFileName(pdbFullPath).ToLowerInvariant();
                 var pdbAge = "FFFFFFFF";
-                indexingPath = $"{pdbFileName}\\{pdbSignature.ToString("N")}{pdbAge}\\{pdbFileName}";
+                indexingPath = $"{pdbFileName}/{pdbSignature.ToString("N")}{pdbAge}/{pdbFileName}";
             }
 
             return indexingPath;

--- a/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
+++ b/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
@@ -57,7 +57,7 @@ namespace NuGet.Services.EndToEnd
 
         public void AssertPackageIsSymbolsPackage(Package package)
         {
-            // The package should have indexed files if its a symbols package
+            // The package should have indexed files if it's a symbols package
             Assert.NotNull(package);
             Assert.True(package.Properties.IsSymbolsPackage);
             Assert.NotNull(package.Properties.IndexedFiles);

--- a/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
+++ b/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using NuGet.Services.EndToEnd.Support;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,10 +41,27 @@ namespace NuGet.Services.EndToEnd
         }
 
         [Fact]
-        public void VerifySymbolsCanbePublished()
+        public async Task VerifySymbolsCanbePublishedAsync()
         {
             // Arrange
-            
+            var symbolsPackage = await _pushedPackages.PrepareAsync(PackageType.SymbolsPackage, _logger);
+
+            // Act & assert
+            AssertPackageIsSymbolsPackage(symbolsPackage);
+            await _clients.SymbolServerClient.VerifySymbolFilesAvailable(
+                symbolsPackage.Id,
+                symbolsPackage.NormalizedVersion,
+                symbolsPackage.Properties.IndexedFiles,
+                _logger);
+        }
+
+        public void AssertPackageIsSymbolsPackage(Package package)
+        {
+            // The package should have indexed files if its a symbols package
+            Assert.NotNull(package);
+            Assert.True(package.Properties.IsSymbolsPackage);
+            Assert.NotNull(package.Properties.IndexedFiles);
+            Assert.True(package.Properties.IndexedFiles.Count() > 0);
         }
     }
 }

--- a/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
+++ b/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using NuGet.Services.EndToEnd.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.EndToEnd
+{
+    /// <summary>
+    /// Tests that integrate with nuget.exe, since this exercises our primary client code.
+    /// </summary>
+    [Collection(nameof(PushedPackagesCollection))]
+    public class SymbolsPackageTests : IClassFixture<TrustedHttpsCertificatesFixture>, IDisposable
+    {
+        private readonly PushedPackagesFixture _pushedPackages;
+        private readonly TestSettings _testSettings;
+        private readonly Clients _clients;
+        private readonly ITestOutputHelper _logger;
+        private readonly TestDirectory _testDirectory;
+        private readonly string _outputDirectory;
+
+        public SymbolsPackageTests(PushedPackagesFixture pushedPackages, ITestOutputHelper logger)
+        {
+            _pushedPackages = pushedPackages;
+            _testSettings = pushedPackages.TestSettings;
+            _clients = pushedPackages.Clients;
+            _logger = logger;
+            _testDirectory = TestDirectory.Create();
+            _outputDirectory = Path.Combine(_testDirectory, "output");
+            Directory.CreateDirectory(_outputDirectory);
+        }
+
+        public void Dispose()
+        {
+            _testDirectory.Dispose();
+        }
+
+        [Fact]
+        public void VerifySymbolsCanbePublished()
+        {
+            // Arrange
+            
+        }
+    }
+}

--- a/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
+++ b/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace NuGet.Services.EndToEnd
 {
     /// <summary>
-    /// Tests that integrate with nuget.exe, since this exercises our primary client code.
+    /// Tests that verify the symbols package related flows
     /// </summary>
     [Collection(nameof(PushedPackagesCollection))]
     public class SymbolsPackageTests : IClassFixture<TrustedHttpsCertificatesFixture>, IDisposable

--- a/src/NuGet.Services.EndToEnd/project.json
+++ b/src/NuGet.Services.EndToEnd/project.json
@@ -6,19 +6,19 @@
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Microsoft.Extensions.Primitives": "1.1.0",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Frameworks": "4.3.0",
-    "NuGet.Packaging": "4.3.0",
-    "NuGet.Protocol": "4.3.0",
+    "NuGet.Frameworks": "4.9.2",
+    "NuGet.Packaging": "4.9.2",
+    "NuGet.Protocol": "4.9.2",
     "NuGet.Services.AzureManagement": "2.2.5",
     "NuGet.Services.Configuration": "2.2.4",
     "NuGet.Services.KeyVault": "2.2.4",
-    "NuGet.Versioning": "4.3.0",
+    "NuGet.Versioning": "4.9.2",
     "System.Reflection.Metadata": "1.7.0-preview.18571.3",
     "xunit": "2.2.0",
-    "xunit.runner.visualstudio": "2.2.0"
+    "xunit.runner.visualstudio": "2.3.1"
   },
   "frameworks": {
-    "net452": {}
+    "net46": {}
   },
   "runtimes": {
     "win": {}

--- a/src/NuGet.Services.EndToEnd/project.json
+++ b/src/NuGet.Services.EndToEnd/project.json
@@ -18,7 +18,7 @@
     "xunit.runner.visualstudio": "2.3.1"
   },
   "frameworks": {
-    "net46": {}
+    "net462": {}
   },
   "runtimes": {
     "win": {}

--- a/src/NuGet.Services.EndToEnd/project.json
+++ b/src/NuGet.Services.EndToEnd/project.json
@@ -13,6 +13,7 @@
     "NuGet.Services.Configuration": "2.2.4",
     "NuGet.Services.KeyVault": "2.2.4",
     "NuGet.Versioning": "4.3.0",
+    "System.Reflection.Metadata": "1.7.0-preview.18571.3",
     "xunit": "2.2.0",
     "xunit.runner.visualstudio": "2.2.0"
   },

--- a/test.ps1
+++ b/test.ps1
@@ -16,7 +16,7 @@ trap {
     exit 1
 }
 
-$CLIRoot= Join-Path $PSScriptRoot 'cli'
+$CLIRoot=$PSScriptRoot
 $env:DOTNET_INSTALL_DIR=$CLIRoot
 
 . "$PSScriptRoot\build\common.ps1"
@@ -35,7 +35,7 @@ else {
 }
 
 Trace-Log "Set signed package path to: '$($env:SignedPackagePath)'"
-Trace-Log "DotNet CLI directory: $($env:DOTNET_INSTALL_DIR)"
+Trace-Log "DotNet Installation directory: $($env:DOTNET_INSTALL_DIR)"
 
 Function Run-Tests {
     [CmdletBinding()]

--- a/test.ps1
+++ b/test.ps1
@@ -16,7 +16,7 @@ trap {
     exit 1
 }
 
-$CLIRoot=$PSScriptRoot
+$CLIRoot= Join-Path $PSScriptRoot 'cli'
 $env:DOTNET_INSTALL_DIR=$CLIRoot
 
 . "$PSScriptRoot\build\common.ps1"
@@ -35,7 +35,7 @@ else {
 }
 
 Trace-Log "Set signed package path to: '$($env:SignedPackagePath)'"
-Trace-Log "DotNet Installation directory: $($env:DOTNET_INSTALL_DIR)"
+Trace-Log "DotNet CLI directory: $($env:DOTNET_INSTALL_DIR)"
 
 Function Run-Tests {
     [CmdletBinding()]

--- a/test.ps1
+++ b/test.ps1
@@ -16,7 +16,7 @@ trap {
     exit 1
 }
 
-$CLIRoot=$PSScriptRoot
+$CLIRoot= Join-Path $PSScriptRoot 'cli'
 $env:DOTNET_INSTALL_DIR=$CLIRoot
 
 . "$PSScriptRoot\build\common.ps1"
@@ -35,6 +35,7 @@ else {
 }
 
 Trace-Log "Set signed package path to: '$($env:SignedPackagePath)'"
+Trace-Log "DotNet CLI directory: $($env:DOTNET_INSTALL_DIR)"
 
 Function Run-Tests {
     [CmdletBinding()]

--- a/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
+++ b/test/NuGet.Services.EndToEnd.Test/NuGet.Services.EndToEnd.Test.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Services.EndToEnd</RootNamespace>
     <AssemblyName>NuGet.Services.EndToEnd.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -62,7 +62,7 @@ namespace NuGet.Services.EndToEnd.Support
             }
 
             _galleryClient.Verify(
-                x => x.PushAsync(It.IsAny<Stream>(), _logger),
+                x => x.PushAsync(It.IsAny<Stream>(), _logger, false),
                 Times.Exactly(expectedPushes));
         }
 
@@ -77,7 +77,7 @@ namespace NuGet.Services.EndToEnd.Support
             // Assert
             Assert.Same(packageA, packageB);
             _galleryClient.Verify(
-                x => x.PushAsync(It.IsAny<Stream>(), _logger),
+                x => x.PushAsync(It.IsAny<Stream>(), _logger, false),
                 Times.Never); // "never" because we reset the mock
         }
 
@@ -97,7 +97,7 @@ namespace NuGet.Services.EndToEnd.Support
             Assert.Equal("1.0.0", package.NormalizedVersion);
             Assert.Equal("1.0.0", package.FullVersion);
             _galleryClient.Verify(
-                x => x.PushAsync(It.IsAny<Stream>(), _logger),
+                x => x.PushAsync(It.IsAny<Stream>(), _logger, false),
                 Times.Once);
         }
     }

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -61,18 +61,18 @@ namespace NuGet.Services.EndToEnd.Support
                 expectedPushes -= 1;
             }
 
-            // If Dotnet env not available symbols package push cannot happen
-            if (string.IsNullOrEmpty(EnvironmentSettings.DotnetCliDirectory))
+            if (expectedPackageTypes.Contains("SymbolsPackage"))
             {
-                expectedPushes -= 1;
-            }
-            else if (expectedPackageTypes.Contains("SymbolsPackage"))
-            {
-                var exists = File.Exists(Path.Combine(EnvironmentSettings.DotnetCliDirectory, "dotnet.exe"));
-                var previous = File.Exists(Path.Combine(Path.GetDirectoryName(EnvironmentSettings.DotnetCliDirectory), "dotnet.exe"));
-                _logger.WriteLine($"Something is wrong: {EnvironmentSettings.DotnetCliDirectory} contains dotnet.exe: {exists}");
-                // The SymbolsPackage type will invoke push twice for nupkg and snupkg each.
-                expectedPushes += 1;
+                if (!DotNetExeClient.TryGetDotNetExe(out string filepath))
+                {
+                    // If Dotnet env not available symbols package push cannot happen;
+                    expectedPushes -= 1;
+                }
+                else
+                {
+                    // symbols package does push twice(nupkg and snupkg) adjust counter appropriately
+                    expectedPushes += 1;
+                }
             }
 
             _galleryClient.Verify(

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -61,11 +61,15 @@ namespace NuGet.Services.EndToEnd.Support
                 expectedPushes -= 1;
             }
 
-            // Ignore symbols package push for now.
-            if (string.IsNullOrEmpty(EnvironmentSettings.DotnetCliDirectory)
-                || expectedPackageTypes.Contains("SymbolsPackage"))
+            // If Dotnet env not available symbols package push cannot happen
+            if (string.IsNullOrEmpty(EnvironmentSettings.DotnetCliDirectory))
             {
                 expectedPushes -= 1;
+            }
+            else if (expectedPackageTypes.Contains("SymbolsPackage"))
+            {
+                // The SymbolsPackage type will invoke push twice for nupkg and snupkg each.
+                expectedPushes += 1;
             }
 
             _galleryClient.Verify(

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -52,10 +52,10 @@ namespace NuGet.Services.EndToEnd.Support
             // Act
             await _fixture.PrepareAsync(PackageType.SemVer1Stable, _logger);
 
-            // Assert - The signed package will only be pushed if a path was provided.
             var expectedPackageTypes = Enum.GetNames(typeof(PackageType));
             var expectedPushes = expectedPackageTypes.Count();
 
+            // Assert - The signed package will only be pushed if a path was provided.
             if (string.IsNullOrEmpty(EnvironmentSettings.SignedPackagePath))
             {
                 expectedPushes -= 1;

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -68,6 +68,9 @@ namespace NuGet.Services.EndToEnd.Support
             }
             else if (expectedPackageTypes.Contains("SymbolsPackage"))
             {
+                var exists = File.Exists(Path.Combine(EnvironmentSettings.DotnetCliDirectory, "dotnet.exe"));
+                var previous = File.Exists(Path.Combine(Path.GetDirectoryName(EnvironmentSettings.DotnetCliDirectory), "dotnet.exe"));
+                _logger.WriteLine($"Something is wrong: {EnvironmentSettings.DotnetCliDirectory} contains dotnet.exe: {exists}");
                 // The SymbolsPackage type will invoke push twice for nupkg and snupkg each.
                 expectedPushes += 1;
             }

--- a/test/NuGet.Services.EndToEnd.Test/project.json
+++ b/test/NuGet.Services.EndToEnd.Test/project.json
@@ -10,7 +10,7 @@
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
-    "net46": {}
+    "net462": {}
   },
   "runtimes": {
     "win": {}


### PR DESCRIPTION
This PR adds end to end test for symbols. Addresses https://github.com/NuGet/NuGetGallery/issues/5520

The test basically, builds sample template project and creates nupkg and snupkg with dlls and pdbs respectively. Pushes this to gallery and then listens to the symbol server endpoint for the availability of the PDB.

Had to update the target framework to net46 due to updated client dependencies which were required to allow symbols validations using client code.

Edit: I will add more tests to this as appropriate.