### PR TITLE
Make path shorter due to long path error on CI

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/TestDirectory.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestDirectory.cs
@@ -22,8 +22,8 @@ namespace NuGet.Services.EndToEnd.Support
 
         public static TestDirectory Create()
         {
-            var baseDirectoryPath = Path.Combine(Path.GetTempPath(), "NuGetTestFolder");
-            var subdirectoryName = Guid.NewGuid().ToString();
+            var baseDirectoryPath = Path.Combine(Path.GetTempPath(), "E2E");
+            var subdirectoryName = DateTimeOffset.UtcNow.Ticks.ToString();
             var fullPath = Path.Combine(baseDirectoryPath, subdirectoryName);
 
             Directory.CreateDirectory(fullPath);


### PR DESCRIPTION
This E2E run failed.
https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=54261
