### PR TITLE
Add "UseOfficialDns" to only determine search instance count from Azure management APIs

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -160,7 +160,8 @@ namespace NuGet.Services.EndToEnd.Support
                     foreach (var url in searchBaseUrls)
                     {
                         // Clean the URL
-                        var host = new Uri(url).Host;
+                        var uri = new Uri(url);
+                        var host = uri.Host;
 
                         if (!_testSettings.SearchServiceConfiguration.IndexJsonMappedSearchServices.ContainsKey(host))
                         {
@@ -169,7 +170,18 @@ namespace NuGet.Services.EndToEnd.Support
 
                         var mappedService = _testSettings.SearchServiceConfiguration.IndexJsonMappedSearchServices[host];
 
-                        searchServices.Add(await GetSearchServiceFromAzureAsync(mappedService, logger));
+                        var searchServiceProperties = await GetSearchServiceFromAzureAsync(mappedService, logger);
+
+                        if (_testSettings.SearchServiceConfiguration.UseOfficialDns)
+                        {
+                            searchServices.Add(new SearchServiceProperties(
+                                ClientHelper.ConvertToHttpsAndClean(uri),
+                                searchServiceProperties.InstanceCount));
+                        }
+                        else
+                        {
+                            searchServices.Add(searchServiceProperties);
+                        }
                     }
                 }
                 else

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -18,6 +18,8 @@ namespace NuGet.Services.EndToEnd.Support
 
         public Dictionary<string, AzureCloudServiceDetails> IndexJsonMappedSearchServices { get; set; }
 
+        public bool UseOfficialDns { get; set; }
+
         public AzureCloudServiceDetails SingleSearchService { get; set; }
     }
 }


### PR DESCRIPTION
This means we don't use the direct cloud service (*.cloudapp.net) name when we are not running E2E tests for search service deployment. We use the official DNS found in the service index.

I ran into this problem because I deployed gallery to INT with the new SSL certificate before search. This should be fine.