### PR TITLE
Add support for E2E tests for Azure search infrastructure.

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -56,7 +56,7 @@
     <Compile Include="Support\Clients\V3IndexClient.cs" />
     <Compile Include="Support\CommonCollection.cs" />
     <Compile Include="Support\CommonFixture.cs" />
-    <Compile Include="Support\Configuration\AzureCloudOrSearchServiceDetails.cs" />
+    <Compile Include="Support\Configuration\ServiceDetails.cs" />
     <Compile Include="Support\Configuration\AzureManagementAPIWrapperConfiguration.cs" />
     <Compile Include="ConnectivityTests.cs" />
     <Compile Include="NuGetExeTests.cs" />

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -56,7 +56,7 @@
     <Compile Include="Support\Clients\V3IndexClient.cs" />
     <Compile Include="Support\CommonCollection.cs" />
     <Compile Include="Support\CommonFixture.cs" />
-    <Compile Include="Support\Configuration\AzureCloudServiceDetails.cs" />
+    <Compile Include="Support\Configuration\AzureCloudOrSearchServiceDetails.cs" />
     <Compile Include="Support\Configuration\AzureManagementAPIWrapperConfiguration.cs" />
     <Compile Include="ConnectivityTests.cs" />
     <Compile Include="NuGetExeTests.cs" />

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SearchServiceProperties.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SearchServiceProperties.cs
@@ -6,19 +6,18 @@ using System;
 namespace NuGet.Services.EndToEnd.Support
 {
     /// <summary>
-    /// Represents a cloud search service with multiple instances.
+    /// Represents a cloud search service with multiple instances. Set the instance count to null to use the 
+    /// provided Uri as is, otherwise the port is appended based on the instance counts.
     /// </summary>
     public class SearchServiceProperties
     {
-        public SearchServiceProperties(Uri uri, int instanceCount, bool isAzureSearch = false)
+        public SearchServiceProperties(Uri uri, int? instanceCount)
         {
             Uri = uri;
             InstanceCount = instanceCount;
-            IsAzureSearch = isAzureSearch;
         }
 
         public Uri Uri { get; }
-        public int InstanceCount { get; }
-        public bool IsAzureSearch { get; }
+        public int? InstanceCount { get; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SearchServiceProperties.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SearchServiceProperties.cs
@@ -10,13 +10,15 @@ namespace NuGet.Services.EndToEnd.Support
     /// </summary>
     public class SearchServiceProperties
     {
-        public SearchServiceProperties(Uri uri, int instanceCount)
+        public SearchServiceProperties(Uri uri, int instanceCount, bool isAzureSearch = false)
         {
             Uri = uri;
             InstanceCount = instanceCount;
+            IsAzureSearch = isAzureSearch;
         }
 
         public Uri Uri { get; }
         public int InstanceCount { get; }
+        public bool IsAzureSearch { get; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -115,7 +115,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         private IEnumerable<string> GetSearchUrlsForPolling(SearchServiceProperties searchServices)
         {
-            if (searchServices.IsAzureSearch)
+            if (!searchServices.InstanceCount.HasValue)
             {
                 var uriBuilder = new UriBuilder(searchServices.Uri)
                 {
@@ -127,7 +127,7 @@ namespace NuGet.Services.EndToEnd.Support
             }
             else
             {
-                for (var instanceIndex = 0; instanceIndex < searchServices.InstanceCount; instanceIndex++)
+                for (var instanceIndex = 0; instanceIndex < searchServices.InstanceCount.Value; instanceIndex++)
                 {
                     var port = MinPort + instanceIndex;
                     var uriBuilder = new UriBuilder(searchServices.Uri)
@@ -209,17 +209,16 @@ namespace NuGet.Services.EndToEnd.Support
 
         private async Task<SearchServiceProperties> GetSearchServiceFromAzureAsync(AzureCloudServiceOrSearchDetails serviceDetails, ITestOutputHelper logger)
         {
-            if (serviceDetails.UseAzureSearchService)
+            if (serviceDetails.UseConfiguredUrls)
             {
                 var serviceUrl = "staging".Equals(serviceDetails.Slot ?? "", StringComparison.OrdinalIgnoreCase)
-                    ? serviceDetails.AzureSearchStagingUrl
-                    : serviceDetails.AzureSearchProductionUrl;
-                logger.WriteLine($"Using Azure search service for {serviceDetails.Slot} with URL: {serviceUrl}");
+                    ? serviceDetails.StagingUrl
+                    : serviceDetails.ProductionUrl;
+                logger.WriteLine($"Using search service for {serviceDetails.Slot} with URL: {serviceUrl}");
 
                 return new SearchServiceProperties(
                     ClientHelper.ConvertToHttpsAndClean(new Uri(serviceUrl)),
-                    instanceCount: 1,
-                    isAzureSearch: true);
+                    instanceCount: null);
             }
             else
             {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -207,7 +207,7 @@ namespace NuGet.Services.EndToEnd.Support
             return searchServices;
         }
 
-        private async Task<SearchServiceProperties> GetSearchServiceFromAzureAsync(AzureCloudServiceOrSearchDetails serviceDetails, ITestOutputHelper logger)
+        private async Task<SearchServiceProperties> GetSearchServiceFromAzureAsync(ServiceDetails serviceDetails, ITestOutputHelper logger)
         {
             if (serviceDetails.UseConfiguredUrls)
             {

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -115,17 +115,30 @@ namespace NuGet.Services.EndToEnd.Support
 
         private IEnumerable<string> GetSearchUrlsForPolling(SearchServiceProperties searchServices)
         {
-            for (var instanceIndex = 0; instanceIndex < searchServices.InstanceCount; instanceIndex++)
+            if (searchServices.IsAzureSearch)
             {
-                var port = MinPort + instanceIndex;
                 var uriBuilder = new UriBuilder(searchServices.Uri)
                 {
                     Scheme = "https",
-                    Port = port,
                     Path = "/search/query"
                 };
 
                 yield return uriBuilder.Uri.ToString();
+            }
+            else
+            {
+                for (var instanceIndex = 0; instanceIndex < searchServices.InstanceCount; instanceIndex++)
+                {
+                    var port = MinPort + instanceIndex;
+                    var uriBuilder = new UriBuilder(searchServices.Uri)
+                    {
+                        Scheme = "https",
+                        Port = port,
+                        Path = "/search/query"
+                    };
+
+                    yield return uriBuilder.Uri.ToString();
+                }
             }
         }
 
@@ -203,7 +216,10 @@ namespace NuGet.Services.EndToEnd.Support
                     : serviceDetails.AzureSearchProductionUrl;
                 logger.WriteLine($"Using Azure search service for {serviceDetails.Slot} with URL: {serviceUrl}");
 
-                return new SearchServiceProperties(ClientHelper.ConvertToHttpsAndClean(new Uri(serviceUrl)), instanceCount: 1);
+                return new SearchServiceProperties(
+                    ClientHelper.ConvertToHttpsAndClean(new Uri(serviceUrl)),
+                    instanceCount: 1,
+                    isAzureSearch: true);
             }
             else
             {

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/AzureCloudOrSearchServiceDetails.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/AzureCloudOrSearchServiceDetails.cs
@@ -3,11 +3,14 @@
 
 namespace NuGet.Services.EndToEnd.Support
 {
-    public class AzureCloudServiceDetails
+    public class AzureCloudServiceOrSearchDetails
     {
         public string Subscription { get; set; }
         public string ResourceGroup { get; set; }
         public string Name { get; set; }
         public string Slot { get; set; }
+        public bool UseAzureSearchService { get; set; }
+        public string AzureSearchProductionUrl { get; set; }
+        public string AzureSearchStagingUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/AzureCloudOrSearchServiceDetails.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/AzureCloudOrSearchServiceDetails.cs
@@ -3,14 +3,15 @@
 
 namespace NuGet.Services.EndToEnd.Support
 {
+    // TODO: Get rid of the old configs used for cloud service https://github.com/NuGet/Engineering/issues/2534 
     public class AzureCloudServiceOrSearchDetails
     {
         public string Subscription { get; set; }
         public string ResourceGroup { get; set; }
         public string Name { get; set; }
         public string Slot { get; set; }
-        public bool UseAzureSearchService { get; set; }
-        public string AzureSearchProductionUrl { get; set; }
-        public string AzureSearchStagingUrl { get; set; }
+        public bool UseConfiguredUrls { get; set; }
+        public string ProductionUrl { get; set; }
+        public string StagingUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/GalleryConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/GalleryConfiguration.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public string GalleryBaseUrl { get; set; }
 
-        public AzureCloudServiceOrSearchDetails ServiceDetails { get; set; }
+        public ServiceDetails ServiceDetails { get; set; }
 
         public AzureManagementAPIWrapperConfiguration AzureManagementAPIWrapperConfiguration { get; set; }
     }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/GalleryConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/GalleryConfiguration.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public string GalleryBaseUrl { get; set; }
 
-        public AzureCloudServiceDetails ServiceDetails { get; set; }
+        public AzureCloudServiceOrSearchDetails ServiceDetails { get; set; }
 
         public AzureManagementAPIWrapperConfiguration AzureManagementAPIWrapperConfiguration { get; set; }
     }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace NuGet.Services.EndToEnd.Support
 {
     /// <summary>
-    /// There are 4 modes for search service configuration:
+    /// There are 3 modes for search service configuration:
     /// 1. SingleSearchService - if not null, only the configured search service will be used.
     /// 2. IndexJsonMappedSearchServices - if not null, we will use all search service instances configured in index.json for testing. This property will provide mapping between index.json
     /// entry and Azure service.

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace NuGet.Services.EndToEnd.Support
 {
     /// <summary>
-    /// There are 3 modes for search service configuration:
+    /// There are 4 modes for search service configuration:
     /// 1. SingleSearchService - if not null, only the configured search service will be used.
     /// 2. IndexJsonMappedSearchServices - if not null, we will use all search service instances configured in index.json for testing. This property will provide mapping between index.json
     /// entry and Azure service.
@@ -16,11 +16,11 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public int OverrideInstanceCount { get; set; }
 
-        public Dictionary<string, AzureCloudServiceDetails> IndexJsonMappedSearchServices { get; set; }
+        public Dictionary<string, AzureCloudServiceOrSearchDetails> IndexJsonMappedSearchServices { get; set; }
 
         public bool UseOfficialDns { get; set; }
 
-        public AzureCloudServiceDetails SingleSearchService { get; set; }
+        public AzureCloudServiceOrSearchDetails SingleSearchService { get; set; }
 
         public AzureManagementAPIWrapperConfiguration AzureManagementAPIWrapperConfiguration { get; set; }
     }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -16,11 +16,11 @@ namespace NuGet.Services.EndToEnd.Support
     {
         public int OverrideInstanceCount { get; set; }
 
-        public Dictionary<string, AzureCloudServiceOrSearchDetails> IndexJsonMappedSearchServices { get; set; }
+        public Dictionary<string, ServiceDetails> IndexJsonMappedSearchServices { get; set; }
 
         public bool UseOfficialDns { get; set; }
 
-        public AzureCloudServiceOrSearchDetails SingleSearchService { get; set; }
+        public ServiceDetails SingleSearchService { get; set; }
 
         public AzureManagementAPIWrapperConfiguration AzureManagementAPIWrapperConfiguration { get; set; }
     }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/ServiceDetails.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/ServiceDetails.cs
@@ -4,7 +4,7 @@
 namespace NuGet.Services.EndToEnd.Support
 {
     // TODO: Get rid of the old configs used for cloud service https://github.com/NuGet/Engineering/issues/2534 
-    public class AzureCloudServiceOrSearchDetails
+    public class ServiceDetails
     {
         public string Subscription { get; set; }
         public string ResourceGroup { get; set; }


### PR DESCRIPTION
I have added minimal changes required for integration with the existing E2E tests. 

Once we get rid of the search cloud service, the E2E tests can be refactored to remove unnecessary configs. Meanwhile we need these to run the E2E tests on the older search service(cloud services).

I validated these changes with the new config in NuGetBuild Dev USNC and it the build passed just fine.

https://github.com/NuGet/Engineering/issues/2534 