### PR TITLE
Poll for some additional time against Azure Search Service

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Services.EndToEnd.Support
@@ -23,5 +24,16 @@ namespace NuGet.Services.EndToEnd.Support
         public ServiceDetails SingleSearchService { get; set; }
 
         public AzureManagementAPIWrapperConfiguration AzureManagementAPIWrapperConfiguration { get; set; }
+
+        /// <summary>
+        /// Additional time to poll after a package was found in the search index. This is necessary for Azure Search
+        /// Service since a package can appear in one Azure Search replica before another. We could go deep into the
+        /// likelihood of hitting N replicas after M queries (a la coupon collector problem) but it is simpler to have
+        /// a duration setting that we can turn up and down for a desired balance between test run time and flakiness.
+        /// Another complexity is that we poll the hijack index but some tests follow up with queries to the search
+        /// index. These two indexes are updated independently (although very close in time) so there are two sources
+        /// of variability in when packages show up in results.
+        /// </summary>
+        public TimeSpan AdditionalPollingDuration { get; set; }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -149,7 +149,7 @@ namespace NuGet.Services.EndToEnd.Support
             {
                 if (_packages.TryGetValue(requestedPackageType, out IReadOnlyList<Package> package))
                 {
-                    logger.WriteLine($"Package of type {requestedPackageType} has already been pushed. Using {package}.");
+                    logger.WriteLine($"Package of type {requestedPackageType} has already been pushed. Using {string.Join(", ", package)}.");
                     return package;
                 }
             }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7320.

With a 30 second wait time introduced and no response caching, total run time went from **14 minutes and 34 seconds** to **38 minutes and 40 seconds**. With response caching the run time is **21 minutes and 29 seconds**.