### PR TITLE
Early failure for missing configuration file.

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -121,9 +121,17 @@ namespace NuGet.Services.EndToEnd.Support
 
         private static async Task<TestSettings> CreateInternalAsync(string configurationName)
         {
+            var configurationDirectoryName = Path.Combine(Environment.CurrentDirectory, "config");
+            var configurationFilename = configurationName + ".json";
+            var configurationFile = new FileInfo(Path.Combine(configurationDirectoryName, configurationFilename));
+            if (!configurationFile.Exists)
+            {
+                throw new InvalidOperationException($"Configuration file not found: {configurationFile.FullName}");
+            }
+
             var builder = new ConfigurationBuilder()
-             .SetBasePath(Path.Combine(Environment.CurrentDirectory, "config"))
-             .AddJsonFile(configurationName + ".json");
+                .SetBasePath(configurationDirectoryName)
+                .AddJsonFile(configurationFilename);
 
             var configurationRoot = builder.Build();
 

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -121,17 +121,9 @@ namespace NuGet.Services.EndToEnd.Support
 
         private static async Task<TestSettings> CreateInternalAsync(string configurationName)
         {
-            var configurationDirectoryName = Path.Combine(Environment.CurrentDirectory, "config");
-            var configurationFilename = configurationName + ".json";
-            var configurationFile = new FileInfo(Path.Combine(configurationDirectoryName, configurationFilename));
-            if (!configurationFile.Exists)
-            {
-                throw new InvalidOperationException($"Configuration file not found: {configurationFile.FullName}");
-            }
-
             var builder = new ConfigurationBuilder()
-                .SetBasePath(configurationDirectoryName)
-                .AddJsonFile(configurationFilename);
+             .SetBasePath(Path.Combine(Environment.CurrentDirectory, "config"))
+             .AddJsonFile(configurationName + ".json");
 
             var configurationRoot = builder.Build();
 

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -123,7 +123,7 @@ namespace NuGet.Services.EndToEnd.Support
         {
             var builder = new ConfigurationBuilder()
              .SetBasePath(Path.Combine(Environment.CurrentDirectory, "config"))
-             .AddJsonFile(configurationName + ".json");
+             .AddJsonFile(configurationName + ".json", optional: false);
 
             var configurationRoot = builder.Build();
 

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -122,8 +122,8 @@ namespace NuGet.Services.EndToEnd.Support
         private static async Task<TestSettings> CreateInternalAsync(string configurationName)
         {
             var builder = new ConfigurationBuilder()
-             .SetBasePath(Path.Combine(Environment.CurrentDirectory, "config"))
-             .AddJsonFile(configurationName + ".json", optional: false);
+                .SetBasePath(Path.Combine(Environment.CurrentDirectory, "config"))
+                .AddJsonFile(configurationName + ".json", optional: false);
 
             var configurationRoot = builder.Build();
 


### PR DESCRIPTION
Useful for running tests locally. Without it it fails with NPE later when accesses a configuration property.