### PR TITLE
[SDL 1] Allow end-to-end tests to run from dev machines

### DIFF
--- a/src/NuGet.Services.EndToEnd/App.config
+++ b/src/NuGet.Services.EndToEnd/App.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NuGet.Services.EndToEnd/PushTests.cs
+++ b/src/NuGet.Services.EndToEnd/PushTests.cs
@@ -87,10 +87,10 @@ namespace NuGet.Services.EndToEnd
                     logger: _logger);
 
                 // Assert
-                Assert.Equal(0, shouldBeEmptyV3.Data.Count);
-                Assert.Equal(0, shouldBeEmptyAutocomplete.Data.Count);
-                Assert.Equal(1, shouldNotBeEmptyV3.Data.Count);
-                Assert.Equal(1, shouldNotBeEmptyAutocomplete.Data.Count);
+                Assert.Empty(shouldBeEmptyV3.Data);
+                Assert.Empty(shouldBeEmptyAutocomplete.Data);
+                Assert.Single(shouldNotBeEmptyV3.Data);
+                Assert.Single(shouldNotBeEmptyAutocomplete.Data);
             }
         }
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Threading;
 using NuGet.Services.AzureManagement;
 
@@ -73,6 +74,10 @@ namespace NuGet.Services.EndToEnd.Support
         /// </summary>
         private static Clients InitializeInternal(TestSettings testSettings)
         {
+            // Ensure that SSLv3 is disabled and that Tls v1.2 is enabled.
+            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             var httpClient = new SimpleHttpClient();
             var gallery = new GalleryClient(httpClient, testSettings, GetAzureManagementAPIWrapperForGallery(testSettings));
             var v3Index = new V3IndexClient(httpClient, testSettings);

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -51,9 +51,14 @@ namespace NuGet.Services.EndToEnd.Support
         {
         }
 
-        public PushedPackagesFixture(IGalleryClient galleryClient)
+        private PushedPackagesFixture(IGalleryClient galleryClient)
         {
             _galleryClient = galleryClient;
+        }
+
+        public static PushedPackagesFixture Create(IGalleryClient galleryClient)
+        {
+            return new PushedPackagesFixture(galleryClient);
         }
 
         public override async Task InitializeAsync()

--- a/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
+++ b/src/NuGet.Services.EndToEnd/SymbolsPackageTests.cs
@@ -55,7 +55,7 @@ namespace NuGet.Services.EndToEnd
                 _logger);
         }
 
-        public void AssertPackageIsSymbolsPackage(Package package)
+        private void AssertPackageIsSymbolsPackage(Package package)
         {
             // The package should have indexed files if it's a symbols package
             Assert.NotNull(package);

--- a/src/NuGet.Services.EndToEnd/project.json
+++ b/src/NuGet.Services.EndToEnd/project.json
@@ -13,8 +13,8 @@
     "NuGet.Services.Configuration": "2.51.0",
     "NuGet.Versioning": "4.9.2",
     "System.Reflection.Metadata": "1.7.0-preview.18571.3",
-    "xunit": "2.2.0",
-    "xunit.runner.visualstudio": "2.3.1"
+    "xunit": "2.4.1",
+    "xunit.runner.visualstudio": "2.4.1"
   },
   "frameworks": {
     "net462": {}

--- a/test/NuGet.Services.EndToEnd.Test/App.config
+++ b/test/NuGet.Services.EndToEnd.Test/App.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.EndToEnd.Support
         public PushedPackagesFixtureTests()
         {
             _galleryClient = new Mock<IGalleryClient>();
-            _fixture = new PushedPackagesFixture(_galleryClient.Object);
+            _fixture = PushedPackagesFixture.Create(_galleryClient.Object);
             _logger = new Mock<ITestOutputHelper>().Object;
         }
 

--- a/test/NuGet.Services.EndToEnd.Test/Support/RetryUtilityTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/RetryUtilityTests.cs
@@ -56,7 +56,7 @@ namespace NuGet.Services.EndToEnd.Support
                 logger: _output));
 
             Assert.Equal(5, attempts);
-            Assert.Equal(actualEx.Message, "Bad! 5");
+            Assert.Equal("Bad! 5", actualEx.Message);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace NuGet.Services.EndToEnd.Support
             Assert.True(
                 stopwatch.Elapsed >= minimum,
                 $"Elapsed was {stopwatch.Elapsed}. Should be greater than or equal to {minimum}.");
-            Assert.Equal(actualEx.Message, "Bad!");
+            Assert.Equal("Bad!", actualEx.Message);
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace NuGet.Services.EndToEnd.Support
                 logger: _output));
 
             Assert.Equal(5, attempts);
-            Assert.Equal(actualEx.Message, "Bad!");
+            Assert.Equal("Bad!", actualEx.Message);
         }
     }
 }

--- a/test/NuGet.Services.EndToEnd.Test/project.json
+++ b/test/NuGet.Services.EndToEnd.Test/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Extensions.Configuration.Json": "1.1.2",
     "Moq": "4.7.8",
     "Newtonsoft.Json": "10.0.2",
-    "xunit": "2.2.0"
+    "xunit": "2.4.1"
   },
   "frameworks": {
     "net462": {}


### PR DESCRIPTION
The end-to-end tests failed on my development machine while using Visual Studio 2019:
* Upgrade XUnit to support VS2019 
* Enforce TLS settings

Tests:
* [`Dev-TestJobs`](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=61585)
* [`Dev-TestGalleryUSNCStaging`](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=61587)

Part of https://github.com/nuget/engineering/issues/2686. Also see:
* SDL 1 - Fixes to end-to-end tests https://github.com/NuGet/NuGet.Services.EndToEnd/pull/94
* SDL 2 - Allows us to use HTTPS protected subdomain in search end-to-end tests https://github.com/NuGet/NuGet.Services.EndToEnd/pull/95
* SDL 3 - Updates end-to-end test configs to use HTTPS protected subdomains [NuGetBuild#1114](https://nuget.visualstudio.com/_git/NuGetBuild/pullrequest/1114?_a=overview)
* SDL 4 - Updates end-to-end tests to no longer ignore invalid HTTPS certificates https://github.com/NuGet/NuGet.Services.EndToEnd/pull/93
* SDL 5 - Update end-to-end test configs to no longer trust the invalid HTTPS certificates
