### PR TITLE
Simplify base URL configuration for gallery and search

### DIFF
--- a/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
+++ b/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Services.EndToEnd
         [Fact]
         public async Task GalleryIsReachable()
         {
-            var galleryUrl = await _clients.Gallery.GetGalleryUrlAsync(_logger);
+            var galleryUrl = _clients.Gallery.GetGalleryServiceBaseUrl();
             using (var httpClient = new HttpClient())
             using (var response = await httpClient.GetAsync(galleryUrl))
             {

--- a/src/NuGet.Services.EndToEnd/LicenseTests.cs
+++ b/src/NuGet.Services.EndToEnd/LicenseTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Services.EndToEnd
         {
             // Arrange
             var package = await _pushedPackages.PrepareAsync(PackageType.LicenseExpression, _logger);
-            var galleryUrl = _clients.Gallery.GetGalleryBaseUrl(_logger);
+            var galleryUrl = _clients.Gallery.GetGalleryBaseUrl();
             var expectedPath = new Uri(galleryUrl, $"packages/{package.Id}/{package.NormalizedVersion}/license");
 
             // Act & Assert
@@ -51,7 +51,7 @@ namespace NuGet.Services.EndToEnd
         {
             // Arrange
             var package = await _pushedPackages.PrepareAsync(PackageType.LicenseFile, _logger);
-            var galleryUrl = _clients.Gallery.GetGalleryBaseUrl(_logger);
+            var galleryUrl = _clients.Gallery.GetGalleryBaseUrl();
             var expectedPath = new Uri(galleryUrl, $"packages/{package.Id}/{package.NormalizedVersion}/license");
 
             // Act & Assert

--- a/src/NuGet.Services.EndToEnd/Support/AssemblyMetadataPackageFile.cs
+++ b/src/NuGet.Services.EndToEnd/Support/AssemblyMetadataPackageFile.cs
@@ -2,12 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.Versioning;
-using System.Text;
-using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Services.EndToEnd.Support.Utilities;
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Net;
 using System.Threading;
 using NuGet.Services.AzureManagement;
@@ -79,7 +78,7 @@ namespace NuGet.Services.EndToEnd.Support
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             var httpClient = new SimpleHttpClient();
-            var gallery = new GalleryClient(httpClient, testSettings, GetAzureManagementAPIWrapperForGallery(testSettings));
+            var gallery = new GalleryClient(httpClient, testSettings);
             var v3Index = new V3IndexClient(httpClient, testSettings);
             var v2v3Search = new V2V3SearchClient(httpClient, v3Index, testSettings, GetAzureManagementAPIWrapperForSearchService(testSettings));
             var flatContainer = new FlatContainerClient(httpClient, v3Index);
@@ -118,7 +117,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapperForSearchService(TestSettings testSettings)
         {
-            if (testSettings.SearchServiceConfiguration.AzureManagementAPIWrapperConfiguration != null)
+            if (testSettings.SearchServiceConfiguration?.AzureManagementAPIWrapperConfiguration != null)
             {
                 return new RetryingAzureManagementAPIWrapper(
                     new AzureManagementAPIWrapper(testSettings.SearchServiceConfiguration.AzureManagementAPIWrapperConfiguration),

--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/IGalleryClient.cs
@@ -11,8 +11,20 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public interface IGalleryClient
     {
-        Task<Uri> GetGalleryUrlAsync(ITestOutputHelper logger);
-        Uri GetGalleryBaseUrl(ITestOutputHelper logger);
+        /// <summary>
+        /// Get the gallery base URL used for interacting with the system. When deploying a component that is not
+        /// NuGetGallery, this will be the well-known public URL. When deploying NuGetGallery, this will be the staging
+        /// slot URL.
+        /// </summary>
+        Uri GetGalleryServiceBaseUrl();
+
+        /// <summary>
+        /// Get the well-known public URL of the NuGetGallery. This method should only be used when asserting the value
+        /// of a URL that is expected to point to the well known URL of NuGetGallery. Use the value returned by
+        /// <see cref="GetGalleryServiceBaseUrl"/> to interact with the gallery endpoints.
+        /// </summary>
+        Uri GetGalleryBaseUrl();
+
         Task PushAsync(Stream nupkgStream, ITestOutputHelper logger, PackageType packageType);
         Task UnlistAsync(string id, string version, ITestOutputHelper logger);
         Task RelistAsync(string id, string version, ITestOutputHelper logger);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/NuGetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/NuGetExeClient.cs
@@ -90,16 +90,16 @@ namespace NuGet.Services.EndToEnd.Support
                 _testSettings,
                 _galleryClient,
                 _version,
-                _sourceType,
+                sourceType,
                 _httpCachePath,
                 _globalPackagesPath);
         }
 
-        private async Task<string> GetSourceAsync(ITestOutputHelper logger)
+        private string GetSource()
         {
             if (_sourceType == SourceType.V2)
             {
-                return $"{await _galleryClient.GetGalleryUrlAsync(logger)}/api/v2";
+                return $"{_galleryClient.GetGalleryServiceBaseUrl()}/api/v2";
             }
 
             return _testSettings.V3IndexUrl;
@@ -112,7 +112,7 @@ namespace NuGet.Services.EndToEnd.Support
                 "restore",
                 projectPath,
                 "-Source",
-                await GetSourceAsync(logger),
+                GetSource(),
             };
 
             var projectDirectory = Path.GetDirectoryName(projectPath);
@@ -127,7 +127,7 @@ namespace NuGet.Services.EndToEnd.Support
                 "install",
                 id,
                 "-Source",
-                await GetSourceAsync(logger),
+                GetSource(),
                 "-OutputDirectory",
                 outputDirectory,
             };
@@ -149,7 +149,7 @@ namespace NuGet.Services.EndToEnd.Support
                 "-Version",
                 version,
                 "-Source",
-                await GetSourceAsync(logger),
+                GetSource(),
                 "-OutputDirectory",
                 outputDirectory,
             };

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -8,18 +8,19 @@ namespace NuGet.Services.EndToEnd.Support
 {
     /// <summary>
     /// There are 3 modes for search service configuration:
-    /// 1. SingleSearchService - if not null, only the configured search service will be used.
-    /// 2. IndexJsonMappedSearchServices - if not null, we will use all search service instances configured in index.json for testing. This property will provide mapping between index.json
-    /// entry and Azure service.
-    /// 3. OverrideInstanceCount - provide a hard coded instance count and don't attempt to get data from Azure.
+    /// 
+    /// 1. Search services from the service index - if there is no Azure Management API configuration set or if there is
+    ///    no SingleSearchService and IndexJsonMappedSearchServices configuration.
+    ///    
+    /// 2. SingleSearchService - if not null, only the configured search service will be used.
+    /// 
+    /// 3. IndexJsonMappedSearchServices - if not null, we will use all search service instances configured in
+    ///    the service index for testing. This property will provide mapping between the service index and necessary
+    ///    configuration for interacting with the search service.
     /// </summary>
     public class SearchServiceConfiguration
     {
-        public int OverrideInstanceCount { get; set; }
-
         public Dictionary<string, ServiceDetails> IndexJsonMappedSearchServices { get; set; }
-
-        public bool UseOfficialDns { get; set; }
 
         public ServiceDetails SingleSearchService { get; set; }
 

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;


### PR DESCRIPTION
### Gallery URL configuration

What configuration is set and when?

- **always set**: `GalleryConfiguration.GalleryBaseUrl` - this is the official URL of gallery that is used for asserting things like license URL in V3 (which points to gallery).
- **set when testing gallery staging**: `GalleryConfiguration.ServiceDetails.BaseUrl` - this is the URL of gallery staging slot used during a gallery deployment.

When E2E test runs need to push packages or run other API calls against the gallery, they use the following precedence order:

1. `GalleryConfiguration.ServiceDetails.BaseUrl` - optional
1. `GalleryConfiguration.GalleryBaseUrl` - required

We never need cloud service details for gallery.

### Search URL configuration

What configuration is set and when?

- **set when deploying search staging**: `SearchServiceConfiguration.SingleSearchService` - this is the base URL for the staging slot used during a search service deployment. There are two variants of search.
  1. Azure Search - just the `BaseUrl` is set.
  1. Legacy Search - `BaseUrl` and cloud service details are set. The cloud service details are used to fetch the instance count. We need the instance count so we can poll all instances for package availability.
- **set when deploying non-search**: `SearchServiceConfiguration.IndexJsonMappedSearchServices` - this is a dictionary mapping all host names found in the service index to service details. There are two variants of the service details. In both cases the base URL used is the one found in the service index.
  1. Azure Search - no properties set.
  1. Legacy Search - Cloud service details are set to in order to fetch instance count.

Our code supports neither `SingleSearchService` or `IndexJsonMappedSearchServices` being set in which case we don't look up instances and use all of the search services from the service index. I don't know why we have this support... maybe for testing locally?

The following precedence order is used:

1. `IndexJsonMappedSearchServices`
1. `SingleSearchService`