### PR TITLE
Block TLS 1.0 and 1.1

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -74,7 +74,7 @@ namespace NuGet.Services.EndToEnd.Support
         /// </summary>
         private static Clients InitializeInternal(TestSettings testSettings)
         {
-            // Ensure that SSLv3 is disabled and that Tls v1.2 is enabled.
+            // Ensure that SSLv3 is disabled and that TLS v1.2 is the minimum TLS version.
             ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
             ServicePointManager.SecurityProtocol &= SecurityProtocolType.Tls;
             ServicePointManager.SecurityProtocol &= SecurityProtocolType.Tls11;

--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -76,6 +76,8 @@ namespace NuGet.Services.EndToEnd.Support
         {
             // Ensure that SSLv3 is disabled and that Tls v1.2 is enabled.
             ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
+            ServicePointManager.SecurityProtocol &= SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol &= SecurityProtocolType.Tls11;
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             var httpClient = new SimpleHttpClient();


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/2617

E2E tests are defaulting to 1.0 and 1.1.