### PR TITLE
Allow null search configuration

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/Clients.cs
@@ -96,25 +96,6 @@ namespace NuGet.Services.EndToEnd.Support
                 symbolServerClient);
         }
 
-        private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapperForGallery(TestSettings testSettings)
-        {
-            if (testSettings.GalleryConfiguration.AzureManagementAPIWrapperConfiguration != null)
-            {
-                return new RetryingAzureManagementAPIWrapper(
-                    new AzureManagementAPIWrapper(testSettings.GalleryConfiguration.AzureManagementAPIWrapperConfiguration),
-                    RetryUtility.DefaultSleepDuration);
-            }
-
-            if (testSettings.AzureManagementAPIWrapperConfiguration != null)
-            {
-                return new RetryingAzureManagementAPIWrapper(
-                    new AzureManagementAPIWrapper(testSettings.AzureManagementAPIWrapperConfiguration),
-                    RetryUtility.DefaultSleepDuration);
-            }
-
-            return null;
-        }
-
         private static IRetryingAzureManagementAPIWrapper GetAzureManagementAPIWrapperForSearchService(TestSettings testSettings)
         {
             if (testSettings.SearchServiceConfiguration?.AzureManagementAPIWrapperConfiguration != null)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -393,7 +393,7 @@ namespace NuGet.Services.EndToEnd.Support
                 _pollCacheLock.Release();
             }
 
-            var additionalPolling = _testSettings.SearchServiceConfiguration.AdditionalPollingDuration;
+            var additionalPolling = _testSettings.SearchServiceConfiguration?.AdditionalPollingDuration ?? TimeSpan.Zero;
             var duration = Stopwatch.StartNew();
             var sinceFirstComplete = new Stopwatch();
             var attempts = 0;


### PR DESCRIPTION
The rest of the system allows null search config. When search config is null all of the search information is gathered from the service index. We should be able to do this when there are no more search cloud services.

Also, delete an unused method.