### PR TITLE
Search test update to override expected registration roots

### DIFF
--- a/src/NuGet.Services.EndToEnd/SearchResultTests.cs
+++ b/src/NuGet.Services.EndToEnd/SearchResultTests.cs
@@ -28,8 +28,8 @@ namespace NuGet.Services.EndToEnd
         public async Task RegistrationValuesInResultMatchRequestSemVerLevel()
         {
             // Arrange
-            var allRegistrationAddresses = await _clients.V3Index.GetRegistrationBaseUrlsAsync(_logger);
-            var semVer2RegistrationAddresses = await _clients.V3Index.GetSemVer2RegistrationBaseUrlsAsync(_logger);
+            var semVer1RegistrationAddresses = await _clients.V3Index.GetRegistrationBaseUrlsAsyncForSearch(_logger);
+            var semVer2RegistrationAddresses = await _clients.V3Index.GetSemVer2RegistrationBaseUrlsAsyncForSearch(_logger);
             var searchServices = await _clients.V2V3Search.GetSearchServicesAsync(_logger);
             
             var semVer2Package = await _pushedPackages.PrepareAsync(PackageType.SemVer2Prerel, _logger);
@@ -45,7 +45,7 @@ namespace NuGet.Services.EndToEnd
             {
                 // Search service changes the registration URL scheme to match the request URL. Modify what we found in
                 // the index.json so match this.
-                var allReg = allRegistrationAddresses.Select(u => MatchSchemeAndPort(searchService.Uri, u));
+                var semVer1Reg = semVer1RegistrationAddresses.Select(u => MatchSchemeAndPort(searchService.Uri, u));
                 var semVer2Reg = semVer2RegistrationAddresses.Select(u => MatchSchemeAndPort(searchService.Uri, u));
 
                 // Act
@@ -62,7 +62,7 @@ namespace NuGet.Services.EndToEnd
                         semVer2Reg.Any(a => semVer1Query.Data[i].Registration.Contains(a)),
                         $"{semVer1Query.Data[i].Id} has a SemVer 2.0.0 registration base URL.");
                     Assert.True(
-                        allReg.Any(a => semVer1Query.Data[i].Registration.Contains(a)),
+                        semVer1Reg.Any(a => semVer1Query.Data[i].Registration.Contains(a)),
                         $"{semVer1Query.Data[i].Id} has should have an expected registration base URL.");
                 }
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
@@ -76,9 +76,9 @@ namespace NuGet.Services.EndToEnd.Support
 
         public async Task<IReadOnlyList<string>> GetSemVer2RegistrationBaseUrlsAsyncForSearch(ITestOutputHelper logger)
         {
-            if (_testSettings.SearchSemver2RegistrationRoots != null && _testSettings.SearchSemver2RegistrationRoots.Length > 0)
+            if (_testSettings.SearchSemVer2RegistrationRoots != null && _testSettings.SearchSemVer2RegistrationRoots.Length > 0)
             {
-                return _testSettings.SearchSemver2RegistrationRoots;
+                return _testSettings.SearchSemVer2RegistrationRoots;
             }
 
             return await GetSemVer2RegistrationBaseUrlsAsync(logger);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
@@ -54,6 +54,16 @@ namespace NuGet.Services.EndToEnd.Support
             return GetResourceUrls(v3Index, "RegistrationsBaseUrl");
         }
 
+        public async Task<IReadOnlyList<string>> GetRegistrationBaseUrlsAsyncForSearch(ITestOutputHelper logger)
+        {
+            if (_testSettings.SearchBaseRegistrationRoots != null && _testSettings.SearchBaseRegistrationRoots.Length > 0)
+            {
+                return _testSettings.SearchBaseRegistrationRoots;
+            }
+
+            return await GetRegistrationBaseUrlsAsync(logger);
+        }
+
         public async Task<IReadOnlyList<string>> GetSemVer2RegistrationBaseUrlsAsync(ITestOutputHelper logger)
         {
             var v3Index = await GetV3IndexAsync(logger);
@@ -62,6 +72,16 @@ namespace NuGet.Services.EndToEnd.Support
                 t => t.Type == "RegistrationsBaseUrl/Versioned" &&
                      t.ClientVersion != null &&
                      NuGetVersion.Parse(t.ClientVersion) >= Version430Alpha);
+        }
+
+        public async Task<IReadOnlyList<string>> GetSemVer2RegistrationBaseUrlsAsyncForSearch(ITestOutputHelper logger)
+        {
+            if (_testSettings.SearchSemver2RegistrationRoots != null && _testSettings.SearchSemver2RegistrationRoots.Length > 0)
+            {
+                return _testSettings.SearchSemver2RegistrationRoots;
+            }
+
+            return await GetSemVer2RegistrationBaseUrlsAsync(logger);
         }
 
         private static List<string> GetResourceUrls(V3Index v3Index, string resourceType)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V3IndexClient.cs
@@ -56,9 +56,9 @@ namespace NuGet.Services.EndToEnd.Support
 
         public async Task<IReadOnlyList<string>> GetRegistrationBaseUrlsAsyncForSearch(ITestOutputHelper logger)
         {
-            if (_testSettings.SearchBaseRegistrationRoots != null && _testSettings.SearchBaseRegistrationRoots.Length > 0)
+            if (_testSettings.SearchRegistrationBaseUrls != null && _testSettings.SearchRegistrationBaseUrls.Any())
             {
-                return _testSettings.SearchBaseRegistrationRoots;
+                return _testSettings.SearchRegistrationBaseUrls;
             }
 
             return await GetRegistrationBaseUrlsAsync(logger);
@@ -76,9 +76,9 @@ namespace NuGet.Services.EndToEnd.Support
 
         public async Task<IReadOnlyList<string>> GetSemVer2RegistrationBaseUrlsAsyncForSearch(ITestOutputHelper logger)
         {
-            if (_testSettings.SearchSemVer2RegistrationRoots != null && _testSettings.SearchSemVer2RegistrationRoots.Length > 0)
+            if (_testSettings.SearchSemVer2RegistrationBaseUrls != null && _testSettings.SearchSemVer2RegistrationBaseUrls.Any())
             {
-                return _testSettings.SearchSemVer2RegistrationRoots;
+                return _testSettings.SearchSemVer2RegistrationBaseUrls;
             }
 
             return await GetSemVer2RegistrationBaseUrlsAsync(logger);

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -126,7 +126,7 @@ namespace NuGet.Services.EndToEnd.Support
         /// <summary>
         /// Override base URLs for Semver 2 registration to be used in Azure Search tests.
         /// </summary>
-        public string[] SearchSemver2RegistrationRoots { get; set; }
+        public string[] SearchSemVer2RegistrationRoots { get; set; }
 
         private static async Task<TestSettings> CreateInternalAsync()
         {

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -116,17 +116,17 @@ namespace NuGet.Services.EndToEnd.Support
         /// and search service configuration will not align at all times. This setting allows providing
         /// overrides for expected registration roots for Search Service tests.
         /// </remarks>
-        public string[] SearchBaseRegistrationRoots { get; set; }
+        public List<string> SearchRegistrationBaseUrls { get; set; }
 
         /// <summary>
         /// Override base URLs for GZipped registration to be used in Azure Search tests.
         /// </summary>
-        public string[] SearchGZipRegistrationRoots { get; set; }
+        public List<string> SearchGZipRegistrationBaseUrls { get; set; }
 
         /// <summary>
         /// Override base URLs for Semver 2 registration to be used in Azure Search tests.
         /// </summary>
-        public string[] SearchSemVer2RegistrationRoots { get; set; }
+        public List<string> SearchSemVer2RegistrationBaseUrls { get; set; }
 
         private static async Task<TestSettings> CreateInternalAsync()
         {

--- a/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestSettings.cs
@@ -85,7 +85,7 @@ namespace NuGet.Services.EndToEnd.Support
             {
                 _semaphore.Release();
             }
-            
+
             return _testSettings;
         }
 
@@ -105,6 +105,28 @@ namespace NuGet.Services.EndToEnd.Support
 
             throw new ArgumentException($"{configurationName} is not one of the local test supported configurations!");
         }
+
+        /// <summary>
+        /// Override base URLs for regular (Semver 1) registration to be used in Azure Search tests.
+        /// </summary>
+        /// <remarks>
+        /// Azure search service has registration root supplied through its own configuration
+        /// that it uses it responses (instead of taking one from the service index file). This makes
+        /// switching to (and testing) the alternative registration hives as service index information
+        /// and search service configuration will not align at all times. This setting allows providing
+        /// overrides for expected registration roots for Search Service tests.
+        /// </remarks>
+        public string[] SearchBaseRegistrationRoots { get; set; }
+
+        /// <summary>
+        /// Override base URLs for GZipped registration to be used in Azure Search tests.
+        /// </summary>
+        public string[] SearchGZipRegistrationRoots { get; set; }
+
+        /// <summary>
+        /// Override base URLs for Semver 2 registration to be used in Azure Search tests.
+        /// </summary>
+        public string[] SearchSemver2RegistrationRoots { get; set; }
 
         private static async Task<TestSettings> CreateInternalAsync()
         {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2784

Currently, E2E tests [fail](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=63169) when run against the non-default registration hive. This happens because one of the tests expects search service responses to contain registration URLs that are rooted to the URLs from service index files. Those are always going to be different when we migrate to a new registration hives.
This update introduces the configuration to allow optional override of expected registration roots.
Also a confusing variables were renamed in the affected test.