### PR TITLE
Set a default additional polling duration in code

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -393,7 +393,7 @@ namespace NuGet.Services.EndToEnd.Support
                 _pollCacheLock.Release();
             }
 
-            var additionalPolling = _testSettings.SearchServiceConfiguration?.AdditionalPollingDuration ?? TimeSpan.Zero;
+            var additionalPolling = _testSettings.SearchServiceConfiguration?.AdditionalPollingDuration ?? SearchServiceConfiguration.DefaultAdditionalPollingDuration;
             var duration = Stopwatch.StartNew();
             var sinceFirstComplete = new Stopwatch();
             var attempts = 0;

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/SearchServiceConfiguration.cs
@@ -20,6 +20,8 @@ namespace NuGet.Services.EndToEnd.Support
     /// </summary>
     public class SearchServiceConfiguration
     {
+        public static readonly TimeSpan DefaultAdditionalPollingDuration = TimeSpan.FromSeconds(30);
+
         public Dictionary<string, ServiceDetails> IndexJsonMappedSearchServices { get; set; }
 
         public ServiceDetails SingleSearchService { get; set; }
@@ -35,6 +37,6 @@ namespace NuGet.Services.EndToEnd.Support
         /// index. These two indexes are updated independently (although very close in time) so there are two sources
         /// of variability in when packages show up in results.
         /// </summary>
-        public TimeSpan AdditionalPollingDuration { get; set; }
+        public TimeSpan AdditionalPollingDuration { get; set; } = DefaultAdditionalPollingDuration;
     }
 }


### PR DESCRIPTION
This is necessary since Azure Search is used in every E2E deployment now.
Without out this the non-Azure Search deployments have flaky end-to-end test results.
Currently the Azure Search deployments have this explicitly set to 30 seconds in config.