### PR TITLE
Use hijack=true to avoid search hijack in a more straight forward way

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -137,11 +137,11 @@ namespace NuGet.Services.EndToEnd.Support
         public async Task SearchPackageODataV2FromDBAsync(string id, string normalizedVersion, ITestOutputHelper logger)
         {
             var galleryEndpoint = GetGalleryServiceBaseUrl();
-            // Add 1 eq 1 to block the search hijack and execute the query against the database.
-            var urlRootAndPath = $"{galleryEndpoint}/api/v2/Packages()";
+            // Add the hijack=false query parameter to block the search hijack and execute the query against the database.
+            var urlRootAndPath = $"{galleryEndpoint}/api/v2/Packages(Id='{id}',Version='{normalizedVersion}')";
             var queryParameters = new Dictionary<string, string>()
             {
-                { "$filter", $"Id eq '{id}' and NormalizedVersion eq '{normalizedVersion}' and 1 eq 1" }
+                { "hijack", "false" }
             };
             var url = QueryHelpers.AddQueryString(urlRootAndPath, queryParameters);
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2902.
This parameter was added here: https://github.com/NuGet/NuGetGallery/pull/8161

When we start blocking custom OData, we this pattern will break.