### PR TITLE
Log output instead of sending it to no where

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -34,8 +34,15 @@ else {
     $env:SignedPackagePath = $signedPackages[0].FullName
 }
 
-Trace-Log "Set signed package path to: '$($env:SignedPackagePath)'"
+Trace-Log "Set signed package path to: $($env:SignedPackagePath)"
 Trace-Log "DotNet CLI directory: $($env:DOTNET_INSTALL_DIR)"
+
+# Try to use the Azure DevOps temp directory, which is cleaned up by the agent and has a short path.
+if ($env:AGENT_TEMPDIRECTORY) {
+    $env:TEMP = $env:AGENT_TEMPDIRECTORY
+}
+
+Trace-Log "Using temp directory: $($env:TEMP)"
 
 Function Run-Tests {
     [CmdletBinding()]

--- a/test.ps1
+++ b/test.ps1
@@ -39,10 +39,12 @@ Trace-Log "DotNet CLI directory: $($env:DOTNET_INSTALL_DIR)"
 
 # Try to use the Azure DevOps temp directory, which is cleaned up by the agent and has a short path.
 if ($env:AGENT_TEMPDIRECTORY) {
+    $env:TMP = $env:AGENT_TEMPDIRECTORY
     $env:TEMP = $env:AGENT_TEMPDIRECTORY
 }
 
-Trace-Log "Using temp directory: $($env:TEMP)"
+Trace-Log "Using TMP directory: $($env:TMP)"
+Trace-Log "Using TEMP directory: $($env:TEMP)"
 
 Function Run-Tests {
     [CmdletBinding()]

--- a/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/PushedPackagesFixtureTests.cs
@@ -17,11 +17,11 @@ namespace NuGet.Services.EndToEnd.Support
         private readonly PushedPackagesFixture _fixture;
         private readonly ITestOutputHelper _logger;
 
-        public PushedPackagesFixtureTests()
+        public PushedPackagesFixtureTests(ITestOutputHelper output)
         {
             _galleryClient = new Mock<IGalleryClient>();
             _fixture = PushedPackagesFixture.Create(_galleryClient.Object);
-            _logger = new Mock<ITestOutputHelper>().Object;
+            _logger = output;
         }
 
         [Theory]


### PR DESCRIPTION
This helps debugging failed tests.