### PR TITLE
Retry on Azure Search and CDN DNS resolution failure

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/V2V3SearchClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -294,7 +295,8 @@ namespace NuGet.Services.EndToEnd.Support
                     await Task.WhenAll(tasks);
                 },
                 ex => ex.HasTypeOrInnerType<SocketException>()
-                   || ex.HasTypeOrInnerType<TaskCanceledException>(),
+                   || ex.HasTypeOrInnerType<TaskCanceledException>()
+                   || (ex.HasTypeOrInnerType<WebException>(out var we) && we.Status == WebExceptionStatus.NameResolutionFailure),
                 logger: logger);
 
         }

--- a/test/NuGet.Services.EndToEnd.Test/Support/HttpResponseMessageExtensionsTests.cs
+++ b/test/NuGet.Services.EndToEnd.Test/Support/HttpResponseMessageExtensionsTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;


### PR DESCRIPTION
Of the past 20 E2E test runs, this is the source of 2 of the failures.
It's not observed on our monitoring sources and always passes on a retry.
This is not worth blocking E2E tests on.