### PR TITLE
Retry on DNS failure for the CDN and symbols URL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# review when someone opens a pull request.
+# For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
+*       @NuGet/gallery-team

--- a/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/FlatContainerClient.cs
@@ -62,7 +62,8 @@ namespace NuGet.Services.EndToEnd.Support
                        && (hre.StatusCode == HttpStatusCode.InternalServerError
                            || hre.StatusCode == HttpStatusCode.BadGateway
                            || hre.StatusCode == HttpStatusCode.ServiceUnavailable
-                           || hre.StatusCode == HttpStatusCode.GatewayTimeout)),
+                           || hre.StatusCode == HttpStatusCode.GatewayTimeout))
+                   || (ex.HasTypeOrInnerType<WebException>(out var we) && we.Status == WebExceptionStatus.NameResolutionFailure),
                 logger: logger);
         }
         
@@ -110,7 +111,8 @@ namespace NuGet.Services.EndToEnd.Support
                        && (hre.StatusCode == HttpStatusCode.InternalServerError
                            || hre.StatusCode == HttpStatusCode.BadGateway
                            || hre.StatusCode == HttpStatusCode.ServiceUnavailable
-                           || hre.StatusCode == HttpStatusCode.GatewayTimeout)),
+                           || hre.StatusCode == HttpStatusCode.GatewayTimeout))
+                   || (ex.HasTypeOrInnerType<WebException>(out var we) && we.Status == WebExceptionStatus.NameResolutionFailure),
                 logger: logger);
         }
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/RegistrationClient.cs
@@ -161,7 +161,8 @@ namespace NuGet.Services.EndToEnd.Support
                        && (hre.StatusCode == HttpStatusCode.InternalServerError
                            || hre.StatusCode == HttpStatusCode.BadGateway
                            || hre.StatusCode == HttpStatusCode.ServiceUnavailable
-                           || hre.StatusCode == HttpStatusCode.GatewayTimeout)),
+                           || hre.StatusCode == HttpStatusCode.GatewayTimeout))
+                   || (ex.HasTypeOrInnerType<WebException>(out var we) && we.Status == WebExceptionStatus.NameResolutionFailure),
                 logger: logger);
         }
 

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -54,7 +54,8 @@ namespace NuGet.Services.EndToEnd.Support
                     await Task.WhenAll(tasks);
                 },
                 ex => ex.HasTypeOrInnerType<SocketException>()
-                    || ex.HasTypeOrInnerType<TaskCanceledException>(),
+                   || ex.HasTypeOrInnerType<TaskCanceledException>()
+                   || (ex.HasTypeOrInnerType<WebException>(out var we) && we.Status == WebExceptionStatus.NameResolutionFailure),
                 logger: logger);
         }
 


### PR DESCRIPTION
On our test agents, we get DNS resolution failures every so often and we don't want to block E2E tests on this.

Example failure: https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=90490&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=05d39475-ccbf-5834-dd1a-48a50eca8e18&l=82

Also add CODEOWNERS file.