### PR TITLE
Add User-Agent header to requests

### DIFF
--- a/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
+++ b/src/NuGet.Services.EndToEnd/ConnectivityTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.Services.EndToEnd
         public async Task GalleryIsReachable()
         {
             var galleryUrl = _clients.Gallery.GetGalleryServiceBaseUrl();
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient().AddUserAgent(nameof(ConnectivityTests)))
             using (var response = await httpClient.GetAsync(galleryUrl))
             {
                 await response.EnsureSuccessStatusCodeOrLogAsync(galleryUrl.AbsoluteUri, _logger);
@@ -39,7 +39,7 @@ namespace NuGet.Services.EndToEnd
         [Fact]
         public async Task V3IndexIsReachable()
         {
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient().AddUserAgent(nameof(ConnectivityTests)))
             using (var response = await httpClient.GetAsync(_testSettings.V3IndexUrl))
             {
                 await response.EnsureSuccessStatusCodeOrLogAsync(_testSettings.V3IndexUrl, _logger);
@@ -55,7 +55,7 @@ namespace NuGet.Services.EndToEnd
             {
                 _logger.WriteLine($"Verifying connectivity to search base URL: {searchService.Uri.AbsoluteUri}");
 
-                using (var httpClient = new HttpClient())
+                using (var httpClient = new HttpClient().AddUserAgent(nameof(ConnectivityTests)))
                 using (var response = await httpClient.GetAsync(searchService.Uri))
                 {
                     await response.EnsureSuccessStatusCodeOrLogAsync(searchService.Uri.AbsoluteUri, _logger);

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Support\AssemblyMetadataPackageFile.cs" />
     <Compile Include="Support\Clients\SymbolServerClient.cs" />
     <Compile Include="Support\FlatContainerContentType.cs" />
+    <Compile Include="Support\HttpClientExtensions.cs" />
     <Compile Include="Support\PackageDeprecationContext.cs" />
     <Compile Include="Support\PackageProperties.cs" />
     <Content Include="Support\TestData\E2E.DotnetTool\Program.cs">

--- a/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/GalleryClient.cs
@@ -82,7 +82,7 @@ namespace NuGet.Services.EndToEnd.Support
                     break;
             }
 
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient().AddUserAgent(nameof(GalleryClient)))
             using (var request = new HttpRequestMessage(HttpMethod.Put, url))
             {
                 // Use the default push timeout that the client uses.
@@ -145,7 +145,7 @@ namespace NuGet.Services.EndToEnd.Support
             };
             var url = QueryHelpers.AddQueryString(urlRootAndPath, queryParameters);
 
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient().AddUserAgent(nameof(GalleryClient)))
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             using (var response = await httpClient.SendAsync(request))
             {
@@ -201,7 +201,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         private async Task SendAsync(HttpMethod method, string url, ITestOutputHelper logger, HttpContent content = null)
         {
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient().AddUserAgent(nameof(GalleryClient)))
             using (var request = new HttpRequestMessage(method, url) { Content = content })
             {
                 request.Headers.Add(ApiKeyHeader, _testSettings.ApiKey);

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SimpleHttpClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SimpleHttpClient.cs
@@ -111,7 +111,7 @@ namespace NuGet.Services.EndToEnd.Support
             Func<Stream, Task<TResult>> getResult)
         {
             using (var httpClientHander = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip })
-            using (var httpClient = new HttpClient(httpClientHander))
+            using (var httpClient = new HttpClient(httpClientHander).AddUserAgent(nameof(SimpleHttpClient)))
             using (var response = await httpClient.GetAsync(url))
             {
                 if (allowNotFound && response.StatusCode == HttpStatusCode.NotFound)

--- a/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/SymbolServerClient.cs
@@ -73,7 +73,7 @@ namespace NuGet.Services.EndToEnd.Support
             var duration = Stopwatch.StartNew();
             while (!complete && duration.Elapsed < TestData.SymbolsWaitDuration)
             {
-                using (var httpClient = new HttpClient())
+                using (var httpClient = new HttpClient().AddUserAgent(nameof(SymbolServerClient)))
                 {
                     // Add Checksum headers for fetching the pdbs from symbol server. This header is used
                     // by the symbol server to validate the request(provided by supported clients) for 

--- a/src/NuGet.Services.EndToEnd/Support/HttpClientExtensions.cs
+++ b/src/NuGet.Services.EndToEnd/Support/HttpClientExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using System.Reflection;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    public static class HttpClientExtensions
+    {
+        public static HttpClient AddUserAgent(this HttpClient httpClient, string clientName)
+        {
+            var assembly = Assembly.GetAssembly(typeof(HttpClientExtensions));
+            var assemblyName = assembly.GetName().Name;
+            var assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
+            httpClient.DefaultRequestHeaders.Add("User-Agent", $"{assemblyName}/{assemblyVersion} ({clientName}; +https://github.com/NuGet/NuGet.Services.EndToEnd)");
+            return httpClient;
+        }
+    }
+}


### PR DESCRIPTION
This is to improve debugging and to align with my plan to require User-Agent for the deprecation API.