### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -165,7 +165,7 @@
       <Version>6.2.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.103.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8363300</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.7.0-preview.18571.3</Version>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/4704

Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault package dependency. Former one is deprecated.
I manually tested this change in [Gallery dev environment](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1478870)