### PR TITLE
Use stable version of Server.Common

### DIFF
--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -165,7 +165,7 @@
       <Version>6.2.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8363300</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.7.0-preview.18571.3</Version>


### PR DESCRIPTION
Related to: https://github.com/NuGet/Engineering/issues/4704
Follow up for comment https://github.com/NuGet/NuGet.Services.EndToEnd/pull/125#discussion_r1320375864, use stable version of Server.Common