### PR TITLE
Switch to .NET Framework 4.7.2 test package

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -14,7 +14,7 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public static class TestData
     {
-        public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net48");
+        public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net472");
         public static readonly TimeSpan FlatContainerWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan SearchWaitDuration = TimeSpan.FromMinutes(35);

--- a/src/NuGet.Services.EndToEnd/Support/TestData.cs
+++ b/src/NuGet.Services.EndToEnd/Support/TestData.cs
@@ -14,7 +14,7 @@ namespace NuGet.Services.EndToEnd.Support
 {
     public static class TestData
     {
-        public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net40");
+        public static readonly NuGetFramework TargetFramework = NuGetFramework.Parse("net48");
         public static readonly TimeSpan FlatContainerWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan RegistrationWaitDuration = TimeSpan.FromMinutes(20);
         public static readonly TimeSpan SearchWaitDuration = TimeSpan.FromMinutes(35);

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>E2E.TestPortableSymbols</RootNamespace>
     <AssemblyName>E2E.TestPortableSymbols</AssemblyName>
-    <TargetFrameworkVersion>v4.8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
+++ b/src/NuGet.Services.EndToEnd/Support/TestData/E2E.TestPortableSymbols/E2E.TestPortableSymbols.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>E2E.TestPortableSymbols</RootNamespace>
     <AssemblyName>E2E.TestPortableSymbols</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>


### PR DESCRIPTION
Our new test agent does not have the .NET 4.0 or .NET 4.6.2 targeting pack. This is easier than updating the test agent.