### PR TITLE
Forcing debug builds for test packages.

### DIFF
--- a/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Clients/DotNetExeClient.cs
@@ -30,6 +30,7 @@ namespace NuGet.Services.EndToEnd.Support
             {
                 "pack",
                 projectPath,
+                "--configuration", "Debug",
                 $"/p:PackageId={id}",
                 $"/p:PackageVersion={version}",
             };

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -155,7 +155,7 @@ namespace NuGet.Services.EndToEnd.Support
 
         /// <summary>
         /// This method will generate the list of applicable packages for a given <see cref="PackageType"/> and
-        /// push them squentially to the NuGet gallery. Note this method will maintain the order of the packages
+        /// push them sequentially to the NuGet gallery. Note this method will maintain the order of the packages
         /// in the list that were pushed to the gallery.
         /// </summary>
         /// <param name="requestedPackageType">The type being currently requested to be pushed to gallery.</param>


### PR DESCRIPTION
E2E tests produce some packages to be used while testing. `dotnet pack` in new SDK [defaults](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack#options) to Release builds, while the rest of the code assumes builds are Debug:
https://github.com/NuGet/NuGet.Services.EndToEnd/blob/d19a29b8a4f808ce428f255dd6d6ceb2eee37dab/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs#L445-L452
As a result, tests fail to find a package when built on up-to-date agents.

This change forces debug builds of test packages, so it continues to work as before.

Also, fixed typo in `PushedPackagesFixture.cs`, line 158, which seem to have updated line endings (aligning with the rest of the repo). That's why the whole file is marked as changed, switch diff viewer to ignore whitespace changes.