### PR TITLE
Add support for getting secrets from environment variables when running tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -54,7 +54,7 @@ Invoke-BuildStep 'Getting private build tools' {
         $configFileName = "$($env:ConfigurationName).json"
         $sourceFile = "$SourcesDirectory\build\private\E2EConfig\$configFileName"
         $destinationDirectory = "$SourcesDirectory\src\NuGet.Services.EndToEnd\ExternalConfig"
-        Write-Host "Copying over configuration file $configFileName from private build tools into $destinationDirectory"
+        Write-Host "Copying configuration file $sourceFile into $destinationDirectory"
         if (-not (Test-Path $destinationDirectory)) {
             New-Item -Path $destinationDirectory -ItemType "directory"
         }

--- a/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
+++ b/src/NuGet.Services.EndToEnd/NuGet.Services.EndToEnd.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ReadmeTests.cs" />
     <Compile Include="Support\AssemblyMetadataPackageFile.cs" />
     <Compile Include="Support\Clients\SymbolServerClient.cs" />
+    <Compile Include="Support\Configuration\EnvVarWrapperSecretReader.cs" />
     <Compile Include="Support\FlatContainerContentType.cs" />
     <Compile Include="Support\HttpClientExtensions.cs" />
     <Compile Include="Support\PackageDeprecationContext.cs" />

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/E2ESecretConfigurationReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/E2ESecretConfigurationReader.cs
@@ -75,7 +75,8 @@ namespace NuGet.Services.EndToEnd.Support
 
         private ISecretInjector InitSecretInjector()
         {
-            return _secretReaderFactory.CreateSecretInjector(_secretReaderFactory.CreateSecretReader());
+            var secretReader = new EnvVarWrapperSecretReader(_secretReaderFactory);
+            return _secretReaderFactory.CreateSecretInjector(secretReader);
         }
     }
 }

--- a/src/NuGet.Services.EndToEnd/Support/Configuration/EnvVarWrapperSecretReader.cs
+++ b/src/NuGet.Services.EndToEnd/Support/Configuration/EnvVarWrapperSecretReader.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.KeyVault;
+
+namespace NuGet.Services.EndToEnd.Support
+{
+    internal class EnvVarWrapperSecretReader : ISecretReader
+    {
+        private readonly Lazy<ISecretReader> _secretReader;
+
+        public EnvVarWrapperSecretReader(ISecretReaderFactory factory) => _secretReader = new Lazy<ISecretReader>(factory.CreateSecretReader);
+        public Task<string> GetSecretAsync(string secretName) => GetSecretAsync(secretName, logger: null);
+        public Task<ISecret> GetSecretObjectAsync(string secretName) => GetSecretObjectAsync(secretName, logger: null);
+
+        public Task<string> GetSecretAsync(string secretName, ILogger logger)
+        {
+            if (TryGetFromEnvironmentVariable(secretName, logger) is string envVarValue)
+            {
+                return Task.FromResult(envVarValue);
+            }
+
+            return _secretReader.Value.GetSecretAsync(secretName, logger);
+        }
+
+        public Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
+        {
+            if (TryGetFromEnvironmentVariable(secretName, logger) is string envVarValue)
+            {
+                ISecret result = new KeyVaultSecret(secretName, envVarValue, null);
+                return Task.FromResult(result);
+            }
+
+            return _secretReader.Value.GetSecretObjectAsync(secretName, logger);
+        }
+
+        private string TryGetFromEnvironmentVariable(string secretName, ILogger logger)
+        {
+            var message = $"Source of secret '{secretName}': ";
+            var envVarValue = Environment.GetEnvironmentVariable(secretName);
+            if (string.IsNullOrWhiteSpace(envVarValue))
+            {
+                message += "KEY VAULT";
+                envVarValue = null;
+            }
+            else
+            {
+                message += "ENV VAR";
+            }
+
+            logger?.LogInformation(message);
+            Console.WriteLine(message);
+
+            return envVarValue;
+        }
+    }
+}


### PR DESCRIPTION
For SFI-ES2.1.2 compliance we need to stop using [NuGet-1ES-Hosted-Pool](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/fa8b3229-dc0f-4633-a285-ad597076921d/resourceGroups/nuget-dev-1es-ci/providers/Microsoft.CloudTest/hostedpools/NuGet-1ES-Hosted-Pool/msi) and/or linked [nuget-testvault-ci](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/fa8b3229-dc0f-4633-a285-ad597076921d/resourcegroups/devkeyvault/providers/microsoft.managedidentity/userassignedidentities/nuget-testvault-ci/overview) Managed Identity, which provided access to key vault secrets needed for test run.

As we create new [NuGetGallery End to End Tests](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=27473) pipeline in DevDiv AzDO we need to use SFI recommended way of accessing key vault on per pipeline basis and passing it via environment variables.

**This change** enables looking up secrets via env vars during test run, falling back to the original way of getting them from key vault 

Addresses https://github.com/NuGet/Engineering/issues/5897