### PR TITLE
Remove the test on package Id with Unicode

### DIFF
--- a/src/NuGet.Services.EndToEnd/AutoCompleteResultTests.cs
+++ b/src/NuGet.Services.EndToEnd/AutoCompleteResultTests.cs
@@ -24,7 +24,6 @@ namespace NuGet.Services.EndToEnd
 
         [GalleryTestTheory]
         [InlineData(PackageType.SemVer1Stable, true, null)]
-        [InlineData(PackageType.SemVer1StableUnicodeId, true, null)]
         [InlineData(PackageType.SemVer1Stable, false, null)]
         [InlineData(PackageType.SemVer2Prerel, true, "2.0.0")]
         [InlineData(PackageType.SemVer2StableMetadata, false, "2.0.0")]

--- a/src/NuGet.Services.EndToEnd/Support/PackageType.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PackageType.cs
@@ -10,7 +10,6 @@ namespace NuGet.Services.EndToEnd.Support
     public enum PackageType
     {
         SemVer1Stable,
-        SemVer1StableUnicodeId,
         SemVer1StableUnlisted,
         SemVer2DueToSemVer2Dep,
         SemVer2Prerel,

--- a/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
+++ b/src/NuGet.Services.EndToEnd/Support/PushedPackagesFixture.cs
@@ -425,11 +425,6 @@ namespace NuGet.Services.EndToEnd.Support
                 case PackageType.DotnetTool:
                     return await PrepareDotnetToolPackageAsync(id, "1.0.0", logger);
 
-                case PackageType.SemVer1StableUnicodeId:
-                    // package Id contains unicode characters.
-                    packageToPrepare = new PackageToPrepare(Package.Create(packageType, id + "пакет包elsökning123", "1.0.0"));
-                    break;
-
                 case PackageType.SemVer1Stable:
                 case PackageType.FullValidation:
                 default:


### PR DESCRIPTION
Package Id with Unicode is no longer valid.